### PR TITLE
feat: add version field to skill frontmatter

### DIFF
--- a/skills/document-writer/SKILL.md
+++ b/skills/document-writer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: document-writer
 description: Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and MDC component usage. Overrides brevity rules for proper grammar. Use nuxt-content for MDC syntax, nuxt-ui for component props.
+version: 1.0.0
 license: MIT
 ---
 

--- a/skills/nuxt-better-auth/SKILL.md
+++ b/skills/nuxt-better-auth/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxt-better-auth
 description: Use when implementing auth in Nuxt apps with @onmax/nuxt-better-auth - provides useUserSession composable, server auth helpers, route protection, and Better Auth plugins integration.
+version: 0.3.0
 license: MIT
 ---
 

--- a/skills/nuxt-content/SKILL.md
+++ b/skills/nuxt-content/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxt-content
 description: Use when working with Nuxt Content v3 - provides collections (local/remote/API sources), queryCollection API, MDC rendering, database configuration, NuxtStudio integration, hooks, i18n patterns, and LLMs integration
+version: 3.0.0
 license: MIT
 ---
 

--- a/skills/nuxt-modules/SKILL.md
+++ b/skills/nuxt-modules/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxt-modules
 description: "Use when creating Nuxt modules: (1) Published npm modules (@nuxtjs/, nuxt-), (2) Local project modules (modules/ directory), (3) Runtime extensions (components, composables, plugins), (4) Server extensions (API routes, middleware), (5) Releasing/publishing modules to npm, (6) Setting up CI/CD workflows for modules. Provides defineNuxtModule patterns, Kit utilities, hooks, E2E testing, and release automation."
+version: 1.0.0
 license: MIT
 ---
 

--- a/skills/nuxt-ui/SKILL.md
+++ b/skills/nuxt-ui/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxt-ui
 description: Use when building styled UI with @nuxt/ui v4 components (Button, Modal, Form, Table, etc.) - provides ready-to-use components with Tailwind Variants theming. Use vue skill for raw component patterns, reka-ui for headless primitives.
+version: 4.3.0
 license: MIT
 ---
 

--- a/skills/nuxt/SKILL.md
+++ b/skills/nuxt/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxt
 description: Use when working on Nuxt 4+ projects - provides server routes, file-based routing, middleware patterns, Nuxt-specific composables, and configuration with latest docs. Covers h3 v1 helpers (validation, WebSocket, SSE) and nitropack v2 patterns.
+version: 4.2.0
 license: MIT
 ---
 

--- a/skills/nuxthub/SKILL.md
+++ b/skills/nuxthub/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nuxthub
 description: Use when building NuxtHub v0.10.4 applications - provides database (Drizzle ORM with sqlite/postgresql/mysql), KV storage, blob storage, and cache APIs. Covers configuration, schema definition, migrations, multi-cloud deployment (Cloudflare, Vercel), and the new hub:db, hub:kv, hub:blob virtual module imports.
+version: 0.10.4
 license: MIT
 ---
 

--- a/skills/reka-ui/SKILL.md
+++ b/skills/reka-ui/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reka-ui
 description: Use when building with Reka UI (headless Vue components) - provides component API, accessibility patterns, composition (asChild), controlled/uncontrolled state, virtualization, and styling integration. Formerly Radix Vue.
+version: 2.0.0
 license: MIT
 ---
 

--- a/skills/ts-library/SKILL.md
+++ b/skills/ts-library/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ts-library
 description: Use when authoring TypeScript libraries - covers project setup, package exports, build tooling (tsdown/unbuild), API design patterns, type inference tricks, testing, and release workflows. Patterns extracted from 20+ high-quality ecosystem libraries.
+version: 1.0.0
 license: MIT
 ---
 

--- a/skills/vue/SKILL.md
+++ b/skills/vue/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vue
 description: Use when editing .vue files, creating Vue 3 components, writing composables, or testing Vue code - provides Composition API patterns, props/emits best practices, VueUse integration, and reactive destructuring guidance
+version: 3.5.0
 license: MIT
 ---
 

--- a/skills/vue/references/components.md
+++ b/skills/vue/references/components.md
@@ -225,6 +225,7 @@ onMounted(() => {
 ```
 
 **Benefits over `ref()`:**
+
 - Type-safe with generics
 - Better IDE autocomplete and refactoring
 - Explicit ref name as string literal

--- a/skills/vue/references/composables.md
+++ b/skills/vue/references/composables.md
@@ -89,6 +89,7 @@ export function usePolling(url: Ref<string>) {
 ```
 
 **Benefits of `onWatcherCleanup()`:**
+
 - Cleaner than returning cleanup functions
 - Works with async watchers
 - Can be called multiple times in same watcher
@@ -233,6 +234,7 @@ export function useCustomElement() {
 ```
 
 **Available in:**
+
 - Components using `<script setup>` in custom elements
 - Access via `this.$host` in Options API
 


### PR DESCRIPTION
## Summary

- Added `version` field to all 10 SKILL.md frontmatter
- Tracks upstream library version or skill version (1.0.0 for original content)

## Versions

| Skill | Version |
|-------|---------|
| nuxt-ui | 4.3.0 |
| nuxt | 4.2.0 |
| vue | 3.5.0 |
| nuxt-content | 3.0.0 |
| nuxthub | 0.10.4 |
| nuxt-better-auth | 0.3.0 |
| reka-ui | 2.0.0 |
| nuxt-modules | 1.0.0 |
| ts-library | 1.0.0 |
| document-writer | 1.0.0 |

Inspired by Vercel's agent-skills pattern.