### PR TITLE
feat(vue): add rules from vue-skills

### DIFF
--- a/skills/vue/SKILL.md
+++ b/skills/vue/SKILL.md
@@ -41,6 +41,8 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 | File in `composables/`   | references/composables.md  |
 | File in `utils/`         | references/utils-client.md |
 | `.spec.ts` or `.test.ts` | references/testing.md      |
+| TypeScript patterns      | references/typescript.md   |
+| Vue Router typing        | references/router.md       |
 
 ## Loading Files
 
@@ -50,6 +52,8 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 - Composable work → [references/composables.md](references/composables.md)
 - Utils work → [references/utils-client.md](references/utils-client.md)
 - Testing → [references/testing.md](references/testing.md)
+- TypeScript → [references/typescript.md](references/typescript.md)
+- Vue Router → [references/router.md](references/router.md)
 
 **DO NOT load all files at once** - wastes context on irrelevant patterns.
 
@@ -57,11 +61,15 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 
 **[references/components.md](references/components.md)** - Props with reactive destructuring, emits patterns, defineModel for v-model, slots shorthand
 
-**[references/composables.md](references/composables.md)** - Composition API structure, VueUse integration, lifecycle hooks, async patterns
+**[references/composables.md](references/composables.md)** - Composition API structure, VueUse integration, lifecycle hooks, async patterns, reactivity gotchas
 
 **[references/utils-client.md](references/utils-client.md)** - Pure functions, formatters, validators, transformers, when NOT to use utils
 
-**[references/testing.md](references/testing.md)** - Vitest + @vue/test-utils, component testing, composable testing, mocking patterns
+**[references/testing.md](references/testing.md)** - Vitest + @vue/test-utils, component testing, composable testing, router mocking
+
+**[references/typescript.md](references/typescript.md)** - InjectionKey for provide/inject, vue-tsc strict templates, tsconfig settings, generic components
+
+**[references/router.md](references/router.md)** - Route meta types, typed params with unplugin-vue-router, scroll behavior, navigation guards
 
 ## Examples
 

--- a/skills/vue/references/components.md
+++ b/skills/vue/references/components.md
@@ -127,6 +127,18 @@ const [title, modifiers] = defineModel<string>({
 
 **⚠️ Warning:** When using `default` without parent providing a value, parent and child can de-sync (parent `undefined`, child has default). Always provide matching defaults in parent or make prop required.
 
+**Prevent double-emit with `required: true`:**
+
+```ts
+// ❌ Without required - emits twice (undefined then value)
+const model = defineModel<Item>()
+
+// ✅ With required - single emit
+const model = defineModel<Item>({ required: true })
+```
+
+Use `required: true` when the model should always have a value to avoid the double-emit issue during initialization.
+
 ### Multiple Models
 
 Default assumes `modelValue` prop. For multiple bindings, use explicit names:
@@ -216,6 +228,24 @@ onMounted(() => {
   </div>
 </template>
 ```
+
+**Component refs with generics:**
+
+For generic components, use `ComponentExposed` from `vue-component-type-helpers`:
+
+```ts
+import type { ComponentExposed } from 'vue-component-type-helpers'
+import MyGenericComponent from './MyGenericComponent.vue'
+
+// Get exposed methods/properties with correct generic types
+const compRef = useTemplateRef<ComponentExposed<typeof MyGenericComponent>>('comp')
+
+onMounted(() => {
+  compRef.value?.someExposedMethod() // Typed!
+})
+```
+
+Install: `pnpm add -D vue-component-type-helpers`
 
 ## SSR Hydration (Vue 3.5+)
 

--- a/skills/vue/references/router.md
+++ b/skills/vue/references/router.md
@@ -1,0 +1,181 @@
+# Vue Router Typing
+
+Type-safe routing patterns for Vue Router.
+
+> **For Nuxt:** Use file-based routing instead. See `nuxt` skill for Nuxt routing patterns.
+
+## Route Meta Types
+
+Extend `RouteMeta` for typed route.meta:
+
+```ts
+// router/types.ts
+import 'vue-router'
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    requiresAuth?: boolean
+    title?: string
+    roles?: ('admin' | 'user')[]
+  }
+}
+```
+
+**Usage:**
+
+```ts
+const route = useRoute()
+route.meta.requiresAuth // boolean | undefined (typed!)
+route.meta.title // string | undefined
+```
+
+## Typed Route Params with unplugin-vue-router
+
+Use `unplugin-vue-router` for fully typed routes:
+
+```bash
+pnpm add -D unplugin-vue-router
+```
+
+```ts
+// vite.config.ts
+import VueRouter from 'unplugin-vue-router/vite'
+
+export default defineConfig({
+  plugins: [VueRouter(), Vue()], // VueRouter BEFORE Vue
+})
+```
+
+**Typed useRoute:**
+
+```ts
+// Auto-generated route types from file structure
+const route = useRoute('/users/[id]')
+route.params.id // string (typed!)
+
+const route = useRoute('/posts/[...slug]')
+route.params.slug // string[] (typed!)
+```
+
+**Typed router.push:**
+
+```ts
+const router = useRouter()
+
+// ✅ Type-checked
+router.push({ name: '/users/[id]', params: { id: '123' } })
+
+// ❌ TypeScript error - wrong param
+router.push({ name: '/users/[id]', params: { userId: '123' } })
+```
+
+## Scroll Behavior Types
+
+Type scroll behavior function:
+
+```ts
+import type { RouterScrollBehavior } from 'vue-router'
+
+const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
+  if (savedPosition) return savedPosition
+  if (to.hash) return { el: to.hash, behavior: 'smooth' }
+  return { top: 0 }
+}
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+  scrollBehavior,
+})
+```
+
+## Dynamic Route Params
+
+Handle union types for dynamic segments:
+
+```ts
+// routes/[type].vue where type can be 'posts' | 'users' | 'comments'
+const route = useRoute()
+
+// Narrow params type
+type ContentType = 'posts' | 'users' | 'comments'
+
+const type = route.params.type as ContentType
+
+// Or use route guards
+if (route.params.type === 'posts') {
+  // TypeScript knows type is 'posts'
+}
+```
+
+## Navigation Guards Types
+
+Type navigation guards:
+
+```ts
+import type { NavigationGuardWithThis, RouteLocationNormalized } from 'vue-router'
+
+const authGuard: NavigationGuardWithThis<undefined> = (to, from) => {
+  if (to.meta.requiresAuth && !isAuthenticated()) {
+    return { name: 'login', query: { redirect: to.fullPath } }
+  }
+}
+
+router.beforeEach(authGuard)
+```
+
+**Per-route guards:**
+
+```ts
+const routes = [
+  {
+    path: '/admin',
+    component: AdminPage,
+    beforeEnter: (to: RouteLocationNormalized) => {
+      if (!hasAdminRole()) return { name: 'forbidden' }
+    },
+  },
+]
+```
+
+## RouteLocation Types
+
+Common route types:
+
+```ts
+import type {
+  RouteLocationNormalized,     // Resolved route (after navigation)
+  RouteLocationNormalizedLoaded, // Current route (from useRoute)
+  RouteLocationRaw,            // Input to router.push()
+  RouteRecordRaw,              // Route config definition
+} from 'vue-router'
+```
+
+## Common Mistakes
+
+**Not extending RouteMeta module:**
+
+```ts
+// ❌ Loses type info
+route.meta.customField // any
+
+// ✅ Extend the interface
+declare module 'vue-router' {
+  interface RouteMeta { customField: string }
+}
+```
+
+**Assuming params are always strings:**
+
+```ts
+// Catch-all routes have string[] params
+const route = useRoute()
+
+// ❌ May be string[]
+const id = route.params.id
+
+// ✅ Handle both cases
+const id = Array.isArray(route.params.id)
+  ? route.params.id[0]
+  : route.params.id
+```

--- a/skills/vue/references/testing.md
+++ b/skills/vue/references/testing.md
@@ -159,6 +159,97 @@ global.fetch = vi.fn(() =>
 )
 ```
 
+## Router Mocking
+
+Mock `useRoute` and `useRouter` for component tests:
+
+```ts
+import { vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({
+    params: { id: '123' },
+    query: { filter: 'active' },
+    path: '/users/123',
+  })),
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+  })),
+}))
+
+it('uses route params', () => {
+  const wrapper = mount(UserPage)
+  expect(wrapper.text()).toContain('123')
+})
+```
+
+**Dynamic route mocking per test:**
+
+```ts
+import { useRoute } from 'vue-router'
+
+it('handles different routes', () => {
+  vi.mocked(useRoute).mockReturnValue({
+    params: { id: '456' },
+  } as any)
+
+  const wrapper = mount(UserPage)
+  expect(wrapper.text()).toContain('456')
+})
+```
+
+## Suspense and Teleport
+
+**Testing async components with Suspense:**
+
+```ts
+import { flushPromises, mount } from '@vue/test-utils'
+
+it('renders async content', async () => {
+  const wrapper = mount(AsyncComponent, {
+    global: {
+      stubs: { Suspense: false }, // Don't stub Suspense
+    },
+  })
+
+  // Wait for async setup to complete
+  await flushPromises()
+
+  expect(wrapper.text()).toContain('Loaded content')
+})
+```
+
+**Testing Teleport:**
+
+```ts
+it('teleports modal content', () => {
+  const wrapper = mount(Modal, {
+    global: {
+      stubs: {
+        teleport: true, // Stub teleport to render inline
+      },
+    },
+  })
+
+  expect(wrapper.text()).toContain('Modal content')
+})
+```
+
+**Access teleported content:**
+
+```ts
+it('finds teleported content', () => {
+  document.body.innerHTML = '<div id="modal-target"></div>'
+
+  mount(Modal, { props: { open: true } })
+
+  // Content teleports to #modal-target
+  expect(document.body.innerHTML).toContain('Modal content')
+})
+```
+
 ## Best Practices
 
 **Do:**

--- a/skills/vue/references/typescript.md
+++ b/skills/vue/references/typescript.md
@@ -1,0 +1,172 @@
+# Vue TypeScript Patterns
+
+TypeScript-specific patterns for Vue 3 development.
+
+## Provide/Inject Types
+
+Use `InjectionKey` for type-safe dependency injection:
+
+```ts
+import type { InjectionKey } from 'vue'
+import type { User } from './types'
+
+// Define typed key
+export const UserKey: InjectionKey<User> = Symbol('user')
+
+// Provider component
+const user = ref<User>({ id: 1, name: 'John' })
+provide(UserKey, user)
+
+// Consumer component
+const user = inject(UserKey) // Ref<User> | undefined
+const user = inject(UserKey)! // Ref<User> (assert non-null)
+```
+
+**With default value:**
+
+```ts
+const user = inject(UserKey, ref({ id: 0, name: 'Guest' }))
+// Type: Ref<User> (no undefined)
+```
+
+## vue-tsc Strict Templates
+
+Enable stricter template type checking:
+
+```bash
+# Check templates with strict mode
+vue-tsc --noEmit --strict-templates
+```
+
+Catches template errors like:
+
+- Accessing non-existent properties
+- Wrong prop types
+- Missing required props
+
+## tsconfig Settings
+
+**Required for Vue 3:**
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "jsx": "preserve"
+  }
+}
+```
+
+**`moduleResolution: "bundler"`** - Matches Vite/webpack resolution. Avoids `.js` extension issues.
+
+**`verbatimModuleSyntax: true`** - Enforces explicit `type` imports:
+
+```ts
+// ❌ May cause issues with bundlers
+import { User } from './types'
+
+// ✅ Explicit type import
+import type { User } from './types'
+```
+
+## Component Type Helpers
+
+**Extract props type from component:**
+
+```ts
+import type { ComponentProps, ComponentSlots, ComponentEmits } from 'vue-component-type-helpers'
+import MyComponent from './MyComponent.vue'
+
+type Props = ComponentProps<typeof MyComponent>
+type Slots = ComponentSlots<typeof MyComponent>
+type Emits = ComponentEmits<typeof MyComponent>
+```
+
+**Extract exposed methods:**
+
+```ts
+import type { ComponentExposed } from 'vue-component-type-helpers'
+
+type Exposed = ComponentExposed<typeof MyComponent>
+```
+
+## Generic Components
+
+Define generic components with typed slots:
+
+```vue
+<script setup lang="ts" generic="T extends { id: string }">
+defineProps<{
+  items: T[]
+}>()
+
+defineSlots<{
+  default: (props: { item: T }) => any
+}>()
+</script>
+
+<template>
+  <div v-for="item in items" :key="item.id">
+    <slot :item="item" />
+  </div>
+</template>
+```
+
+## Ref Type Narrowing
+
+Handle ref type narrowing correctly:
+
+```ts
+const maybeUser = ref<User | null>(null)
+
+// ❌ TypeScript still sees User | null
+if (maybeUser.value) {
+  maybeUser.value.name // Error: possibly null
+}
+
+// ✅ Use computed or extract value
+const userName = computed(() => maybeUser.value?.name ?? 'Guest')
+
+// ✅ Or guard in same expression
+maybeUser.value && maybeUser.value.name
+```
+
+## Event Handler Types
+
+Type event handlers correctly:
+
+```ts
+// DOM events
+const onClick = (e: MouseEvent) => { ... }
+const onInput = (e: Event) => {
+  const target = e.target as HTMLInputElement
+  console.log(target.value)
+}
+
+// Component emits
+const onUpdate = (value: string) => { ... }
+```
+
+## Common Mistakes
+
+**Forgetting to import types explicitly:**
+
+```ts
+// ❌ Runtime import of type-only
+import { User } from './types'
+
+// ✅ Type-only import
+import type { User } from './types'
+```
+
+**Not using `as const` for literal types:**
+
+```ts
+// ❌ Type is string[]
+const variants = ['primary', 'secondary']
+
+// ✅ Type is readonly ['primary', 'secondary']
+const variants = ['primary', 'secondary'] as const
+```


### PR DESCRIPTION
Add Vue patterns from @hyf0 to existing skills.

## Changes
- **composables.md** - Reactivity gotchas (ref unwrapping, watchEffect tracking, cleanup)
- **components.md** - defineModel `required: true`, ComponentExposed for generics
- **testing.md** - Router mocking, Suspense/Teleport testing
- **NEW typescript.md** - InjectionKey, vue-tsc strict, tsconfig settings
- **NEW router.md** - Route meta types, typed params, navigation guards
- **vueuse/SKILL.md** - SSR gotchas, target element refs

Co-authored-by: hyf0 <hyf0@users.noreply.github.com>