### PR TITLE
feat: track hyf0/vue-skills upstream

### DIFF
--- a/.github/workflows/skill-maintenance.yml
+++ b/.github/workflows/skill-maintenance.yml
@@ -36,10 +36,11 @@ jobs:
         include:
           - skill: vue
             upstream: |
+              - GitHub: hyf0/vue-skills (PRIORITY - our rules are based on this repo)
               - GitHub: vuejs/core (releases, changelog)
               - Docs: https://vuejs.org/guide/introduction.html
               - VueUse: https://vueuse.org/ (new composables)
-            focus: 'Composition API, reactivity, VueUse composables, defineModel, reactive destructuring'
+            focus: 'Composition API, reactivity, VueUse composables, defineModel, reactive destructuring, patterns from hyf0/vue-skills'
 
           - skill: nuxt
             upstream: |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The maintenance workflow uses [claude-code-action](https://github.com/anthropics
 - [OpenCode Skills](https://opencode.ai/docs/skills/) - Agent skills in OpenCode
 - [awesome-copilot](https://github.com/github/awesome-copilot) - Community collection of custom agents and prompts
 
+## Acknowledgments
+
+- **vue** skill based on patterns from [@hyf0](https://github.com/hyf0)'s [vue-skills](https://github.com/hyf0/vue-skills)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Problem
Vue rules come from @hyf0's vue-skills repo but we had no tracking mechanism.

## Changes
- Add `hyf0/vue-skills` as priority upstream in maintenance workflow
- Create `UPSTREAM.md` to document tracked sources
- Add attribution in vue SKILL.md