### PR TITLE
feat: add vitest, vite, pnpm, tsdown skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -106,6 +106,38 @@
       "description": "Nuxt SEO meta-module with robots, sitemap, og-image, schema-org. Use when configuring SEO, generating sitemaps, creating OG images, or adding structured data.",
       "keywords": ["nuxt", "seo", "robots", "sitemap", "og-image", "schema-org", "meta-tags"],
       "category": "frontend"
+    },
+    {
+      "name": "vitest",
+      "source": "./skills/vitest",
+      "version": "1.0.0",
+      "description": "Vitest testing framework with Vite integration. Use when writing unit tests, mocking modules, testing types, or configuring test coverage.",
+      "keywords": ["vitest", "testing", "unit-tests", "mocking", "coverage", "snapshot", "type-testing"],
+      "category": "tooling"
+    },
+    {
+      "name": "vite",
+      "source": "./skills/vite",
+      "version": "1.0.0",
+      "description": "Vite build tool with HMR and production builds. Use when configuring dev server, plugins, SSR, library mode, or troubleshooting build issues.",
+      "keywords": ["vite", "build", "hmr", "plugins", "ssr", "library-mode", "rolldown"],
+      "category": "tooling"
+    },
+    {
+      "name": "pnpm",
+      "source": "./skills/pnpm",
+      "version": "1.0.0",
+      "description": "pnpm package manager with workspaces and catalogs. Use when managing dependencies, setting up monorepos, or configuring CI/CD with pnpm.",
+      "keywords": ["pnpm", "package-manager", "workspaces", "monorepo", "catalogs", "ci-cd"],
+      "category": "tooling"
+    },
+    {
+      "name": "tsdown",
+      "source": "./skills/tsdown",
+      "version": "1.0.0",
+      "description": "tsdown TypeScript library bundler powered by Rolldown. Use when building libraries, generating DTS files, or configuring package exports.",
+      "keywords": ["tsdown", "bundler", "typescript", "dts", "rolldown", "library"],
+      "category": "tooling"
     }
   ]
 }

--- a/.github/workflows/skill-maintenance.yml
+++ b/.github/workflows/skill-maintenance.yml
@@ -20,6 +20,10 @@ on:
           - nuxt-better-auth
           - nuxt-modules
           - reka-ui
+          - vitest
+          - vite
+          - pnpm
+          - tsdown
 
 permissions:
   contents: write
@@ -87,6 +91,34 @@ jobs:
               - Docs: https://reka-ui.com/
             focus: 'Component APIs, props/emits/slots, new components, accessibility'
 
+          - skill: vitest
+            upstream: |
+              - GitHub: antfu/skills (SYNCED - primary source)
+              - GitHub: vitest-dev/vitest (releases, changelog)
+              - Docs: https://vitest.dev/
+            focus: 'Test API, mocking, coverage, type testing, config options'
+
+          - skill: vite
+            upstream: |
+              - GitHub: antfu/skills (SYNCED - primary source)
+              - GitHub: vitejs/vite (releases, changelog)
+              - Docs: https://vite.dev/
+            focus: 'Config, plugins, HMR, build modes, SSR, library mode'
+
+          - skill: pnpm
+            upstream: |
+              - GitHub: antfu/skills (SYNCED - primary source)
+              - GitHub: pnpm/pnpm (releases, changelog)
+              - Docs: https://pnpm.io/
+            focus: 'Workspaces, catalogs, CLI commands, CI/CD patterns'
+
+          - skill: tsdown
+            upstream: |
+              - GitHub: antfu/skills (SYNCED - primary source)
+              - GitHub: rolldown/tsdown (releases, changelog)
+              - Docs: https://tsdown.dev/
+            focus: 'Config, DTS generation, output formats, plugins'
+
     steps:
       - name: Skip if not matching manual input
         if: github.event.inputs.skill != '' && github.event.inputs.skill != 'all' && github.event.inputs.skill != matrix.skill
@@ -149,3 +181,58 @@ jobs:
 
           claude_args: |
             --allowedTools "Read,Write,Edit,Glob,Grep,WebFetch,Bash(git:*),Bash(gh:*),Bash(curl:*)"
+
+  # Track antfu/skills for new skills or major rewrites
+  sync-antfu-skills:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.skill == '' || github.event.inputs.skill == 'all'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Clone antfu/skills
+        run: git clone --depth 1 https://github.com/antfu/skills.git /tmp/antfu-skills
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: claude-sonnet-4-20250514
+          timeout_minutes: 20
+          prompt: |
+            ## Task
+            Sync skills from antfu/skills upstream repository.
+
+            **Our skills from antfu/skills:** vitest, vite, pnpm, tsdown
+
+            ## Steps
+
+            1. **Check for new skills in antfu/skills**
+               - List skills in /tmp/antfu-skills/skills/
+               - Compare with our skills/ directory
+               - Identify any NEW skills we don't have (exclude: vue, nuxt, antfu, slidev, turborepo, unocss, vitepress, vue-best-practices, vueuse, web-design-guidelines - we have our own or don't need)
+
+            2. **Check for updates in synced skills**
+               For each of: vitest, vite, pnpm, tsdown
+               - Compare /tmp/antfu-skills/skills/{skill}/ with skills/{skill}/
+               - Check if SKILL.md structure changed significantly
+               - Check if new reference files were added
+               - Check if existing references have major updates
+
+            3. **If changes found, create PR**
+               - Branch: sync-antfu-skills-YYYYMMDD
+               - Copy new/updated files (skip GENERATION.md files)
+               - Update marketplace.json if new skills added
+               - Update README.md if new skills added
+               - Commit: "chore: sync with antfu/skills upstream"
+               - Create PR with detailed changelog
+
+            4. **If no changes needed**
+               - Output "antfu/skills is in sync"
+
+            ## Important
+            - Do NOT copy GENERATION.md files
+            - Keep our SKILL.md descriptions if they're better suited for our audience
+            - Update the upstream tracking comment in synced SKILL.md files
+          claude_args: |
+            --allowedTools "Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(ls:*),Bash(diff:*),Bash(cp:*)"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Clone the repository and copy skill folders to your agent's skills directory:
 | **motion**           | Motion Vue animations - motion component, composables, scroll, gestures         |
 | **vueuse**           | VueUse composables - state, browser, sensors, network, animation utilities      |
 | **nuxt-seo**         | Nuxt SEO meta-module - robots, sitemap, og-image, schema-org, site config       |
+| **vitest**           | Vitest testing - test API, mocking, coverage, type testing, environments        |
+| **vite**             | Vite build tool - config, plugins, HMR, SSR, library mode, performance          |
+| **pnpm**             | pnpm package manager - workspaces, catalogs, CLI commands, CI/CD                |
+| **tsdown**           | tsdown bundler - TypeScript libraries, DTS generation, Rolldown-powered         |
 
 ## How Skills Work
 
@@ -111,7 +115,11 @@ nuxt-skills/
 │   ├── ts-library/
 │   ├── motion/
 │   ├── vueuse/
-│   └── nuxt-seo/
+│   ├── nuxt-seo/
+│   ├── vitest/
+│   ├── vite/
+│   ├── pnpm/
+│   └── tsdown/
 └── .claude-plugin/
     └── marketplace.json    # Claude Code marketplace
 ```
@@ -139,6 +147,7 @@ The maintenance workflow uses [claude-code-action](https://github.com/anthropics
 ## Acknowledgments
 
 - **vue** skill based on patterns from [@hyf0](https://github.com/hyf0)'s [vue-skills](https://github.com/hyf0/vue-skills)
+- **vitest**, **vite**, **pnpm**, **tsdown** skills from [@antfu](https://github.com/antfu)'s [skills](https://github.com/antfu/skills)
 
 ## License
 

--- a/skills/pnpm/SKILL.md
+++ b/skills/pnpm/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pnpm
+description: Fast, disk space efficient package manager for Node.js with strict dependency resolution and monorepo support
+license: MIT
+---
+
+# pnpm
+
+Content-addressable store, strict deps, workspace protocol, catalogs.
+
+## When to Use
+
+- Installing/managing npm packages
+- Monorepo workspace setup
+- Overriding transitive dependencies
+- Patching third-party packages
+- CI/CD configuration for pnpm projects
+
+## Quick Start
+
+```bash
+pnpm install                      # Install deps
+pnpm add <pkg>                    # Add dep
+pnpm add -D <pkg>                 # Dev dep
+pnpm -r run build                 # Run in all packages
+pnpm --filter @myorg/app build    # Run in specific package
+```
+
+## Workspace Setup
+
+```yaml
+# pnpm-workspace.yaml
+packages:
+  - 'packages/*'
+  - 'apps/*'
+
+catalog:
+  react: ^18.2.0
+  typescript: ~5.3.0
+```
+
+```json
+// package.json
+{
+  "dependencies": {
+    "@myorg/utils": "workspace:^",
+    "react": "catalog:"
+  }
+}
+```
+
+## Reference Files
+
+| Task                             | File                                      |
+| -------------------------------- | ----------------------------------------- |
+| Commands, scripts, filtering     | [cli.md](references/cli.md)               |
+| Workspaces, catalogs, config     | [workspaces.md](references/workspaces.md) |
+| Overrides, patches, hooks, store | [features.md](references/features.md)     |
+| CI/CD, Docker, migration         | [ci.md](references/ci.md)                 |
+
+## Load Based on Task
+
+**Installing packages?** → Load `cli.md`
+**Setting up monorepo?** → Load `workspaces.md`
+**Fixing dep issues?** → Load `features.md`
+**Configuring CI?** → Load `ci.md`
+
+## Cross-Skill References
+
+- **TypeScript libs** → Use `ts-library` skill for library patterns
+- **Build tooling** → Use `tsdown` or `vite` skills

--- a/skills/pnpm/references/ci.md
+++ b/skills/pnpm/references/ci.md
@@ -1,0 +1,241 @@
+# CI/CD & Migration
+
+## GitHub Actions
+
+### Basic Setup
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+      - run: pnpm build
+```
+
+### With Store Caching
+
+```yaml
+- uses: pnpm/action-setup@v4
+  with:
+    version: 9
+
+- name: Get pnpm store directory
+  shell: bash
+  run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+- uses: actions/cache@v4
+  with:
+    path: ${{ env.STORE_PATH }}
+    key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+    restore-keys: |
+      ${{ runner.os }}-pnpm-store-
+
+- run: pnpm install --frozen-lockfile
+```
+
+### Monorepo - Build Changed Only
+
+```yaml
+- name: Build changed packages
+  run: pnpm --filter "...[origin/main]" build
+```
+
+## GitLab CI
+
+```yaml
+image: node:20
+
+variables:
+  PNPM_HOME: /root/.local/share/pnpm
+  PATH: $PNPM_HOME:$PATH
+
+before_script:
+  - corepack enable
+  - corepack prepare pnpm@latest --activate
+
+cache:
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+    - .pnpm-store
+
+install:
+  script:
+    - pnpm config set store-dir .pnpm-store
+    - pnpm install --frozen-lockfile
+```
+
+## Docker
+
+### Multi-Stage Build
+
+```dockerfile
+FROM node:20-slim AS builder
+RUN corepack enable
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/*/package.json ./packages/
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM node:20-slim AS runner
+RUN corepack enable
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile --prod
+CMD ["node", "dist/index.js"]
+```
+
+## Key CI Flags
+
+```bash
+--frozen-lockfile    # Always use in CI
+--prefer-offline     # Use cached packages
+--ignore-scripts     # Faster (careful: some deps need scripts)
+```
+
+## Corepack
+
+```json
+// package.json
+{
+  "packageManager": "pnpm@9.0.0"
+}
+```
+
+```yaml
+# CI
+- run: corepack enable
+- run: pnpm install --frozen-lockfile
+```
+
+## Migration from npm
+
+```bash
+rm -rf node_modules package-lock.json
+pnpm install
+```
+
+## Migration from Yarn
+
+```bash
+rm -rf node_modules yarn.lock
+rm -rf .yarn .yarnrc.yml  # Yarn Berry
+pnpm install
+```
+
+## Import Lockfile
+
+```bash
+pnpm import  # Creates pnpm-lock.yaml from existing lockfile
+```
+
+## Handling Phantom Dependencies
+
+pnpm is strict - imports must be in package.json:
+
+```bash
+# Error: lodash not found (it's a transitive dep)
+# Solution: add it explicitly
+pnpm add lodash
+```
+
+## Symlink Issues
+
+Some tools don't work with symlinks:
+
+```ini
+# .npmrc - Use npm-like flat structure
+node-linker=hoisted
+```
+
+Or hoist specific packages:
+
+```ini
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*babel*
+```
+
+## Monorepo Migration
+
+1. Create `pnpm-workspace.yaml`:
+
+   ```yaml
+   packages:
+     - 'packages/*'
+   ```
+
+2. Update internal deps to workspace protocol:
+
+   ```json
+   { "@myorg/utils": "workspace:^" }
+   ```
+
+3. Install:
+   ```bash
+   rm -rf node_modules packages/*/node_modules
+   pnpm install
+   ```
+
+## Performance Tips
+
+```ini
+# .npmrc
+prefer-offline=true
+side-effects-cache=true
+workspace-concurrency=4
+
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=@swc/core
+```
+
+```bash
+# Build changed only
+pnpm --filter "...[origin/main]" build
+
+# Parallel workspace
+pnpm -r --parallel run test
+
+# Clean store periodically
+pnpm store prune
+```
+
+## Scripts Migration
+
+```json
+{
+  "scripts": {
+    // npm workspaces
+    "build:all": "npm run build --workspaces",
+    // pnpm
+    "build:all": "pnpm -r run build",
+
+    // npm specific workspace
+    "dev:app": "npm run dev -w packages/app",
+    // pnpm
+    "dev:app": "pnpm --filter @myorg/app run dev"
+  }
+}
+```

--- a/skills/pnpm/references/cli.md
+++ b/skills/pnpm/references/cli.md
@@ -1,0 +1,167 @@
+# CLI Commands
+
+## Installation
+
+```bash
+pnpm install              # Install all deps
+pnpm i                    # Alias
+
+pnpm install --frozen-lockfile  # CI mode - fail if lockfile outdated
+pnpm install --prefer-offline   # Use cache when available
+pnpm install --prod             # Production only
+pnpm install --no-optional      # Skip optional deps
+pnpm install --ignore-scripts   # Skip lifecycle scripts
+```
+
+## Adding Dependencies
+
+```bash
+pnpm add <pkg>            # Production dep
+pnpm add -D <pkg>         # Dev dep
+pnpm add -O <pkg>         # Optional dep
+pnpm add -g <pkg>         # Global
+
+pnpm add <pkg>@<version>  # Specific version
+pnpm add <pkg>@next       # Tag
+pnpm add <pkg>@^1.0.0     # Range
+```
+
+## Removing Dependencies
+
+```bash
+pnpm remove <pkg>
+pnpm rm <pkg>
+pnpm uninstall <pkg>
+pnpm un <pkg>
+```
+
+## Updating Dependencies
+
+```bash
+pnpm update               # Update all
+pnpm up <pkg>             # Update specific
+
+pnpm up --latest          # Ignore semver
+pnpm up -L                # Alias
+
+pnpm up --interactive     # Interactive mode
+pnpm up -i                # Alias
+```
+
+## Running Scripts
+
+```bash
+pnpm run <script>         # Run script
+pnpm <script>             # Shorthand
+
+pnpm run build -- --watch # Pass args
+pnpm run --if-present build  # No error if missing
+```
+
+## Executing Binaries
+
+```bash
+pnpm exec <cmd>           # Run local binary
+pnpm exec eslint .        # Example
+
+pnpm dlx <pkg>            # Like npx, no install
+pnpm dlx create-vite my-app
+```
+
+## Workspace Commands
+
+```bash
+pnpm -r run <script>      # Run in all packages
+pnpm --recursive run <script>
+
+pnpm -r --parallel run build    # Parallel
+pnpm -r --stream run dev        # Stream output
+pnpm -r --workspace-concurrency=1 run build  # Sequential
+```
+
+## Filtering
+
+```bash
+# By package name
+pnpm --filter <name> <cmd>
+pnpm -F <name> <cmd>
+pnpm --filter "@scope/pkg" build
+
+# By directory
+pnpm --filter "./packages/core" test
+
+# Glob patterns
+pnpm --filter "@myorg/*" lint
+pnpm --filter "!@myorg/internal-*" publish
+
+# Dependencies of package
+pnpm --filter "...@scope/app" build
+
+# Dependents of package
+pnpm --filter "@scope/core..." test
+
+# Changed since git ref
+pnpm --filter "...[origin/main]" build
+pnpm --filter "[HEAD~5]" lint
+```
+
+## Link Packages
+
+```bash
+pnpm link --global        # Make global
+pnpm link -g
+
+pnpm link --global <pkg>  # Use linked package
+```
+
+## Patching
+
+```bash
+pnpm patch <pkg>@<version>     # Create temp dir for editing
+pnpm patch-commit <path>       # Save patch
+pnpm patch-remove <pkg>        # Remove patch
+```
+
+## Store Management
+
+```bash
+pnpm store path           # Show location
+pnpm store prune          # Remove unused
+pnpm store status         # Check integrity
+pnpm store add <pkg>      # Add without installing
+```
+
+## Information Commands
+
+```bash
+pnpm list                 # List installed
+pnpm ls --depth=0         # Top-level only
+pnpm ls --json            # JSON output
+
+pnpm why <pkg>            # Why installed
+pnpm outdated             # Show outdated
+pnpm audit                # Security check
+```
+
+## Other Commands
+
+```bash
+pnpm import               # Import from npm/yarn lockfile
+pnpm rebuild              # Rebuild native modules
+pnpm pack                 # Create tarball
+pnpm publish              # Publish to registry
+pnpm publish -r --no-git-checks  # CI publish
+```
+
+## Environment
+
+```bash
+# Using Corepack (recommended)
+corepack enable
+corepack prepare pnpm@latest --activate
+
+# package.json
+{
+  "packageManager": "pnpm@9.0.0"
+}
+```

--- a/skills/pnpm/references/features.md
+++ b/skills/pnpm/references/features.md
@@ -1,0 +1,221 @@
+# Features
+
+## Overrides
+
+Force specific versions of dependencies:
+
+```yaml
+# pnpm-workspace.yaml (recommended)
+overrides:
+  lodash: ^4.17.21
+  'foo@^1.0.0': ^1.2.3           # Specific parent version
+  'express>cookie': ^0.6.0        # Nested dep
+  'underscore': 'npm:lodash@^4'   # Replace package
+  'unwanted-pkg': '-'             # Remove entirely
+```
+
+Or in package.json:
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "lodash": "^4.17.21"
+    }
+  }
+}
+```
+
+## Patches
+
+Modify third-party packages:
+
+```bash
+# 1. Start patch
+pnpm patch express@4.18.2
+# Output: /tmp/abc123...
+
+# 2. Edit files in temp dir
+cd /tmp/abc123...
+# Make changes
+
+# 3. Commit patch
+pnpm patch-commit /tmp/abc123...
+```
+
+Creates `patches/express@4.18.2.patch` and updates package.json:
+
+```json
+{
+  "pnpm": {
+    "patchedDependencies": {
+      "express@4.18.2": "patches/express@4.18.2.patch"
+    }
+  }
+}
+```
+
+```bash
+pnpm patch-remove express@4.18.2  # Remove patch
+```
+
+## Aliases
+
+Install packages under different names:
+
+```json
+{
+  "dependencies": {
+    "lodash3": "npm:lodash@3",
+    "lodash4": "npm:lodash@4"
+  }
+}
+```
+
+```ts
+import lodash3 from 'lodash3'
+import lodash4 from 'lodash4'
+```
+
+Replace packages:
+
+```json
+{
+  "dependencies": {
+    "request": "npm:@cypress/request@^3.0.0"
+  }
+}
+```
+
+## Hooks (.pnpmfile.cjs)
+
+```js
+// .pnpmfile.cjs
+function readPackage(pkg, context) {
+  // Add missing peer dep
+  if (pkg.name === 'broken-package') {
+    pkg.peerDependencies = {
+      ...pkg.peerDependencies,
+      react: '*',
+    }
+  }
+
+  // Override version
+  if (pkg.dependencies?.lodash) {
+    pkg.dependencies.lodash = '^4.17.21'
+  }
+
+  // Remove unwanted dep
+  delete pkg.optionalDependencies?.fsevents
+
+  return pkg
+}
+
+function afterAllResolved(lockfile, context) {
+  context.log(`Resolved ${Object.keys(lockfile.packages || {}).length} packages`)
+  return lockfile
+}
+
+module.exports = {
+  hooks: {
+    readPackage,
+    afterAllResolved,
+  },
+}
+```
+
+## Peer Dependencies
+
+```ini
+# .npmrc
+auto-install-peers=true        # Default in pnpm v8+
+strict-peer-dependencies=false # Don't fail on issues
+```
+
+Suppress warnings:
+
+```json
+{
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["@babel/*", "eslint"],
+      "allowedVersions": {
+        "react": "17 || 18",
+        "@types/react": "*"
+      },
+      "allowAny": ["@types/*"]
+    }
+  }
+}
+```
+
+## Store
+
+Content-addressable storage - packages stored once globally, hard-linked to projects.
+
+```
+~/.pnpm-store/              # Global store
+└── v3/files/<hash>/
+
+project/node_modules/
+├── .pnpm/                  # Virtual store (hard links)
+│   ├── lodash@4.17.21/
+│   └── express@4.18.2/
+├── lodash -> .pnpm/lodash@4.17.21/...
+└── express -> .pnpm/express@4.18.2/...
+```
+
+### Node Linker Modes
+
+```ini
+# Default - strict, no phantom deps
+node-linker=isolated
+
+# npm-like flat structure
+node-linker=hoisted
+
+# Yarn PnP mode
+node-linker=pnp
+```
+
+### Store Commands
+
+```bash
+pnpm store path
+pnpm store prune
+pnpm store status
+```
+
+### Troubleshooting
+
+```ini
+# For Docker/network drives
+package-import-method=copy
+```
+
+## Side Effects Cache
+
+Cache native module builds:
+
+```ini
+side-effects-cache=true
+```
+
+## Security
+
+```ini
+# Only build specific deps
+onlyBuiltDependencies[]=esbuild
+onlyBuiltDependencies[]=sharp
+
+# Skip all scripts
+ignore-scripts=true
+```
+
+```json
+{
+  "pnpm": {
+    "neverBuiltDependencies": ["fsevents", "cpu-features"]
+  }
+}
+```

--- a/skills/pnpm/references/workspaces.md
+++ b/skills/pnpm/references/workspaces.md
@@ -1,0 +1,208 @@
+# Workspaces & Configuration
+
+## pnpm-workspace.yaml
+
+```yaml
+packages:
+  - 'packages/*'
+  - 'apps/*'
+  - 'tools/*/packages/*'
+  - '!**/test/**'  # Exclude
+
+# Catalogs for shared versions
+catalog:
+  react: ^18.2.0
+  typescript: ~5.3.0
+  vite: ^5.0.0
+
+catalogs:
+  react17:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+  react18:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+
+# Overrides
+overrides:
+  lodash: ^4.17.21
+  'foo@^1.0.0>bar': ^2.0.0
+
+# Settings (alternative to .npmrc)
+settings:
+  auto-install-peers: true
+  strict-peer-dependencies: false
+  link-workspace-packages: true
+```
+
+## Workspace Protocol
+
+Reference local packages:
+
+```json
+{
+  "dependencies": {
+    "@myorg/utils": "workspace:*",
+    "@myorg/core": "workspace:^",
+    "@myorg/types": "workspace:~"
+  }
+}
+```
+
+| Protocol           | Behavior    | Published As |
+| ------------------ | ----------- | ------------ |
+| `workspace:*`      | Any version | `1.2.3`      |
+| `workspace:^`      | Compatible  | `^1.2.3`     |
+| `workspace:~`      | Patch       | `~1.2.3`     |
+| `workspace:^1.0.0` | Range       | `^1.0.0`     |
+
+## Catalogs
+
+Centralized version management:
+
+```yaml
+# pnpm-workspace.yaml
+catalog:
+  lodash: ^4.17.21
+  zod: ^3.22.0
+```
+
+```json
+// package.json
+{
+  "dependencies": {
+    "lodash": "catalog:",
+    "zod": "catalog:"
+  }
+}
+```
+
+Named catalogs:
+
+```json
+{
+  "dependencies": {
+    "react": "catalog:react18"
+  }
+}
+```
+
+On publish, `catalog:` becomes actual version.
+
+## .npmrc Settings
+
+```ini
+# Peer deps
+auto-install-peers=true
+strict-peer-dependencies=false
+
+# Hoisting
+public-hoist-pattern[]=*types*
+public-hoist-pattern[]=*eslint*
+shamefully-hoist=false
+
+# Store
+store-dir=~/.pnpm-store
+virtual-store-dir=node_modules/.pnpm
+
+# Lockfile
+lockfile=true
+prefer-frozen-lockfile=true
+
+# Performance
+side-effects-cache=true
+
+# Registry
+registry=https://registry.npmjs.org/
+@myorg:registry=https://npm.myorg.com/
+
+# Workspace
+link-workspace-packages=true
+prefer-workspace-packages=true
+shared-workspace-lockfile=true
+save-workspace-protocol=rolling
+
+# Node.js
+use-node-version=20.10.0
+node-version-file=.nvmrc
+```
+
+## package.json pnpm Field
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "lodash": "^4.17.21"
+    },
+    "peerDependencyRules": {
+      "ignoreMissing": ["@babel/*"],
+      "allowedVersions": { "react": "17 || 18" },
+      "allowAny": ["@types/*"]
+    },
+    "neverBuiltDependencies": ["fsevents"],
+    "onlyBuiltDependencies": ["esbuild"],
+    "patchedDependencies": {
+      "express@4.18.2": "patches/express@4.18.2.patch"
+    }
+  }
+}
+```
+
+## Configuration Hierarchy
+
+1. `/etc/npmrc` - Global
+2. `~/.npmrc` - User
+3. `<project>/.npmrc` - Project
+4. `npm_config_<key>=<value>` - Environment
+5. `pnpm-workspace.yaml` settings
+
+## Project Structure
+
+```
+my-monorepo/
+├── pnpm-workspace.yaml
+├── package.json
+├── pnpm-lock.yaml
+├── .npmrc
+├── packages/
+│   ├── core/
+│   │   └── package.json
+│   ├── utils/
+│   │   └── package.json
+│   └── types/
+│       └── package.json
+└── apps/
+    ├── web/
+    │   └── package.json
+    └── api/
+        └── package.json
+```
+
+## Workspace Scripts
+
+```bash
+# Install specific package dep
+pnpm --filter @myorg/app add lodash
+
+# Add workspace dep
+pnpm --filter @myorg/app add @myorg/utils
+
+# Run in topological order
+pnpm -r run build
+
+# Run in parallel
+pnpm -r --parallel run test
+
+# Execute in all packages
+pnpm -r exec rm -rf dist
+```
+
+## Publishing
+
+```bash
+pnpm publish -r                    # Publish all changed
+pnpm publish -r --no-git-checks    # CI mode
+```
+
+`workspace:*` → actual version on publish.

--- a/skills/ts-library/SKILL.md
+++ b/skills/ts-library/SKILL.md
@@ -29,6 +29,7 @@ Patterns for authoring high-quality TypeScript libraries, extracted from studyin
 | Package exports       | [references/package-exports.md](references/package-exports.md)     |
 | tsconfig options      | [references/typescript-config.md](references/typescript-config.md) |
 | Build configuration   | [references/build-tooling.md](references/build-tooling.md)         |
+| ESLint config         | [references/eslint-config.md](references/eslint-config.md)         |
 | API design patterns   | [references/api-design.md](references/api-design.md)               |
 | Type inference tricks | [references/type-patterns.md](references/type-patterns.md)         |
 | Testing setup         | [references/testing.md](references/testing.md)                     |

--- a/skills/ts-library/references/eslint-config.md
+++ b/skills/ts-library/references/eslint-config.md
@@ -1,0 +1,120 @@
+# @antfu/eslint-config
+
+Flat ESLint config that handles both linting and formatting - replaces Prettier.
+
+## Setup
+
+```bash
+pnpm add -D eslint @antfu/eslint-config
+```
+
+```js
+// eslint.config.mjs
+import antfu from '@antfu/eslint-config'
+
+export default antfu()
+```
+
+```json
+{ "scripts": { "lint": "eslint ." } }
+```
+
+## Configuration Options
+
+```js
+import antfu from '@antfu/eslint-config'
+
+export default antfu({
+  type: 'lib',        // 'lib' for libraries, 'app' for applications
+  ignores: ['**/fixtures', '**/dist'],
+  stylistic: { indent: 2, quotes: 'single' },
+  typescript: true,   // Auto-detected
+  vue: true,          // Auto-detected
+})
+```
+
+## Framework Support
+
+| Framework | Option         | Required Package                                        |
+| --------- | -------------- | ------------------------------------------------------- |
+| Vue       | `vue: true`    | (auto-detected)                                         |
+| React     | `react: true`  | `@eslint-react/eslint-plugin eslint-plugin-react-hooks` |
+| Next.js   | `nextjs: true` | `@next/eslint-plugin-next`                              |
+| Svelte    | `svelte: true` | `eslint-plugin-svelte`                                  |
+| Astro     | `astro: true`  | `eslint-plugin-astro`                                   |
+| Solid     | `solid: true`  | `eslint-plugin-solid`                                   |
+| UnoCSS    | `unocss: true` | `@unocss/eslint-plugin`                                 |
+
+## Formatters (CSS, HTML, Markdown)
+
+For files ESLint doesn't handle natively:
+
+```js
+export default antfu({
+  formatters: {
+    css: true,      // Prettier for CSS/LESS/SCSS
+    html: true,     // Prettier for HTML
+    markdown: 'prettier' // or 'dprint'
+  }
+})
+// Requires: pnpm add -D eslint-plugin-format
+```
+
+## Rule Overrides
+
+### Global
+
+```js
+export default antfu(
+  { /* config options */ },
+  { rules: { 'style/semi': ['error', 'never'] } }
+)
+```
+
+### Per-integration
+
+```js
+export default antfu({
+  vue: { overrides: { 'vue/operator-linebreak': ['error', 'before'] } },
+  typescript: { overrides: { 'ts/consistent-type-definitions': ['error', 'interface'] } },
+})
+```
+
+## Plugin Prefix Renaming
+
+| New Prefix | Original               |
+| ---------- | ---------------------- |
+| `ts/*`     | `@typescript-eslint/*` |
+| `style/*`  | `@stylistic/*`         |
+| `import/*` | `import-lite/*`        |
+| `node/*`   | `n/*`                  |
+| `test/*`   | `vitest/*`             |
+
+```ts
+// eslint-disable-next-line ts/consistent-type-definitions
+```
+
+## Type-Aware Rules
+
+```js
+export default antfu({
+  typescript: { tsconfigPath: 'tsconfig.json' },
+})
+```
+
+## VS Code Settings
+
+```jsonc
+{
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit", "source.organizeImports": "never" },
+  "eslint.rules.customizations": [
+    { "rule": "style/*", "severity": "off", "fixable": true },
+    { "rule": "format/*", "severity": "off", "fixable": true },
+    { "rule": "*-indent", "severity": "off", "fixable": true },
+    { "rule": "*-spacing", "severity": "off", "fixable": true }
+  ],
+  "eslint.validate": ["javascript", "typescript", "vue", "html", "markdown", "json", "yaml"]
+}
+```

--- a/skills/tsdown/SKILL.md
+++ b/skills/tsdown/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tsdown
+description: tsdown is a fast and elegant TypeScript library bundler powered by Rolldown and Oxc
+license: MIT
+---
+
+# tsdown
+
+Rolldown + Oxc powered TypeScript bundler. Drop-in tsup replacement.
+
+## When to Use
+
+- Building TypeScript libraries
+- Generating .d.ts declarations
+- Publishing npm packages
+- Dual ESM/CJS output
+- Vue/React component libraries
+
+## Quick Start
+
+```bash
+npm i -D tsdown typescript
+```
+
+```ts
+// tsdown.config.ts
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  format: 'esm',
+  dts: true,
+  exports: true,
+})
+```
+
+```bash
+tsdown           # Build
+tsdown --watch   # Watch mode
+```
+
+## Reference Files
+
+| Task                                    | File                                  |
+| --------------------------------------- | ------------------------------------- |
+| Config file, CLI, entry points          | [config.md](references/config.md)     |
+| Format, target, dts, exports            | [output.md](references/output.md)     |
+| Shims, unbundle, watch, frameworks      | [features.md](references/features.md) |
+| Plugins, hooks, programmatic, migration | [advanced.md](references/advanced.md) |
+
+## Load Based on Task
+
+**Setting up config?** → Load `config.md`
+**Configuring output?** → Load `output.md`
+**Using features?** → Load `features.md`
+**Plugins/migration?** → Load `advanced.md`
+
+## Cross-Skill References
+
+- **Library patterns** → Use `ts-library` skill
+- **Vue component libs** → Use `vue` skill
+- **Package management** → Use `pnpm` skill

--- a/skills/tsdown/references/advanced.md
+++ b/skills/tsdown/references/advanced.md
@@ -1,0 +1,193 @@
+# Advanced
+
+## Plugins
+
+### Supported Types
+
+- **Rolldown** - Native support
+- **Unplugin** - Most `unplugin-*` work
+- **Rollup** - Most work (may need type cast)
+- **Vite** - May work if not using Vite internals
+
+```ts
+import UnpluginVue from 'unplugin-vue/rolldown'
+import SomeRollupPlugin from 'some-rollup-plugin'
+
+defineConfig({
+  plugins: [
+    UnpluginVue({ isProduction: true }),
+    SomeRollupPlugin() as any,  // Type cast for Rollup plugins
+  ],
+})
+```
+
+### Custom Plugin
+
+```ts
+defineConfig({
+  plugins: [
+    {
+      name: 'my-plugin',
+      transform(code, id) {
+        if (id.endsWith('.txt')) {
+          return `export default ${JSON.stringify(code)}`
+        }
+      },
+    },
+  ],
+})
+```
+
+See [Rolldown Plugin API](https://rolldown.rs/guide/plugin-development).
+
+## Hooks
+
+Build lifecycle:
+
+```ts
+// Object syntax
+defineConfig({
+  hooks: {
+    'build:prepare': (context) => {
+      console.log('Preparing build...')
+    },
+    'build:before': (context, format) => {
+      console.log(`Building ${format}...`)
+    },
+    'build:done': async (context) => {
+      await generateDocs()
+      console.log('Build complete!')
+    },
+  },
+})
+
+// Function syntax
+defineConfig({
+  hooks(hooks) {
+    hooks.hook('build:prepare', () => {
+      console.log('Starting...')
+    })
+  },
+})
+```
+
+## Programmatic API
+
+```ts
+import { build } from 'tsdown'
+
+await build({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  outDir: 'dist',
+  dts: true,
+  exports: true,
+})
+```
+
+Multiple builds:
+
+```ts
+await build([
+  { entry: ['src/node.ts'], platform: 'node', outDir: 'dist/node' },
+  { entry: ['src/browser.ts'], platform: 'browser', outDir: 'dist/browser' },
+])
+```
+
+## Rolldown Options
+
+### inputOptions
+
+```ts
+defineConfig({
+  inputOptions: {
+    cwd: './custom-directory',
+    resolve: {
+      mainFields: ['module', 'main'],
+      alias: { '@': './src' },
+    },
+    transform: {
+      jsx: 'react',
+    },
+  },
+})
+```
+
+Function syntax for format-specific:
+
+```ts
+defineConfig({
+  inputOptions(options, format) {
+    if (format === 'cjs') {
+      options.cwd = './cjs-specific'
+    }
+    return options
+  },
+})
+```
+
+### outputOptions
+
+```ts
+defineConfig({
+  outputOptions: {
+    legalComments: 'inline',  // Preserve license headers
+  },
+})
+```
+
+Format-specific:
+
+```ts
+defineConfig({
+  outputOptions(options, format) {
+    if (format === 'esm') {
+      options.legalComments = 'inline'
+    }
+    return options
+  },
+})
+```
+
+## Migration from tsup
+
+### Automatic
+
+```bash
+npx tsdown-migrate
+npx tsdown-migrate packages/*  # Monorepo
+npx tsdown-migrate --dry-run   # Preview
+```
+
+### Changed Defaults
+
+| Option   | tsup    | tsdown                        |
+| -------- | ------- | ----------------------------- |
+| `format` | -       | `esm`                         |
+| `clean`  | `false` | `true`                        |
+| `dts`    | `false` | Auto-enabled if `types` field |
+| `target` | -       | Reads `engines.node`          |
+
+### No Stub Mode
+
+tsdown doesn't support stub mode. Alternatives:
+
+1. **Watch mode**: `tsdown --watch`
+2. **Dev exports**: `exports: { devExports: true }`
+3. **TypeScript runners**: vite-node, tsx, jiti, Node.js v22.18+
+
+## Performance Tips
+
+1. Enable `isolatedDeclarations` in tsconfig for fast `.d.ts`
+2. Use `skipNodeModulesBundle: true` if not bundling deps
+3. Disable sourcemaps in production if not needed
+
+## Debugging
+
+```bash
+# Verbose output
+DEBUG=tsdown:* tsdown
+
+# Dry run (migration)
+npx tsdown-migrate --dry-run
+```

--- a/skills/tsdown/references/config.md
+++ b/skills/tsdown/references/config.md
@@ -1,0 +1,204 @@
+# Configuration & CLI
+
+## Config File
+
+Supported files (searched in order):
+
+- `tsdown.config.ts` / `.mts` / `.cts`
+- `tsdown.config.js` / `.mjs` / `.cjs`
+- `tsdown.config.json`
+- `tsdown` field in `package.json`
+
+```ts
+// tsdown.config.ts
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  dts: true,
+  exports: true,
+})
+```
+
+## Multiple Configurations
+
+```ts
+import { defineConfig } from 'tsdown'
+
+export default defineConfig([
+  {
+    entry: 'src/node.ts',
+    platform: 'node',
+  },
+  {
+    entry: 'src/browser.ts',
+    platform: 'browser',
+  },
+])
+```
+
+## Entry Points
+
+```ts
+// Single entry
+defineConfig({
+  entry: 'src/index.ts',
+})
+
+// Multiple entries
+defineConfig({
+  entry: ['src/entry1.ts', 'src/entry2.ts'],
+})
+
+// Entry aliases → dist/main.js, dist/utils.js
+defineConfig({
+  entry: {
+    main: 'src/index.ts',
+    utils: 'src/utils.ts',
+  },
+})
+
+// Glob patterns
+defineConfig({
+  entry: 'src/**/*.ts',
+})
+```
+
+## CLI Commands
+
+```bash
+tsdown                          # Build
+tsdown src/index.ts             # Specify entry
+tsdown --watch                  # Watch mode
+tsdown -w
+
+tsdown --config ./path/to/config
+tsdown --no-config              # Skip config file
+```
+
+## CLI Options
+
+```bash
+# Output
+--format esm|cjs|iife|umd
+--format esm --format cjs       # Multiple formats
+-d ./build                      # Output dir
+--out-dir ./build
+
+# Declaration files
+--dts
+
+# Target
+--target es2020
+--target node20
+--no-target                     # Preserve modern syntax
+
+# Platform
+--platform node|browser|neutral
+
+# Optimization
+--minify
+--sourcemap
+--treeshake
+--no-treeshake
+
+# Cleaning
+--clean                         # Default: true
+--no-clean
+
+# External
+--external lodash
+--external "@my-scope/*"
+
+# Watch
+--watch [path]
+--ignore-watch node_modules
+
+# Env
+--env.NODE_ENV=production
+--env-file .env.production
+--env-prefix APP_
+
+# Post-build
+--on-success "echo Done!"
+
+# Copy assets
+--copy public
+
+# Package exports
+--exports
+```
+
+## CLI Flag Patterns
+
+```bash
+--foo              # foo: true
+--no-foo           # foo: false
+--foo.bar          # foo: { bar: true }
+--format esm --format cjs  # format: ['esm', 'cjs']
+```
+
+## Config Loaders
+
+```bash
+tsdown --config-loader auto     # Default
+tsdown --config-loader native   # Node.js TypeScript
+tsdown --config-loader unrun    # More powerful
+```
+
+## Extend Vite/Vitest Config
+
+Reuse `resolve` and `plugins`:
+
+```bash
+tsdown --from-vite              # Load vite.config.*
+tsdown --from-vite vitest       # Load vitest.config.*
+```
+
+## Common Configurations
+
+### Pure ESM Library
+
+```ts
+defineConfig({
+  entry: 'src/index.ts',
+  format: 'esm',
+  dts: true,
+  exports: true,
+  target: 'es2020',
+})
+```
+
+### Dual ESM/CJS
+
+```ts
+defineConfig({
+  entry: 'src/index.ts',
+  format: ['esm', 'cjs'],
+  dts: true,
+  exports: true,
+})
+```
+
+### Node.js CLI
+
+```ts
+defineConfig({
+  entry: 'src/cli.ts',
+  format: 'esm',
+  platform: 'node',
+  dts: true,
+  shims: true,  // __dirname, __filename in ESM
+})
+```
+
+### Browser Library
+
+```ts
+defineConfig({
+  entry: 'src/index.ts',
+  format: ['esm', 'iife'],
+  platform: 'browser',
+  minify: true,
+})
+```

--- a/skills/tsdown/references/features.md
+++ b/skills/tsdown/references/features.md
@@ -1,0 +1,244 @@
+# Features
+
+## Tree Shaking
+
+Enabled by default - removes unused code.
+
+```ts
+defineConfig({
+  treeshake: true,   // Default
+  treeshake: false,  // Disable
+})
+```
+
+## Minification
+
+```ts
+defineConfig({
+  minify: true,
+})
+```
+
+Uses Oxc (fast, currently alpha).
+
+## Source Maps
+
+```ts
+defineConfig({
+  sourcemap: true,
+})
+```
+
+Auto-enabled if `declarationMap: true` in tsconfig.json.
+
+## Shims
+
+### CJS in ESM
+
+`__dirname` and `__filename` not available in ESM:
+
+```ts
+defineConfig({
+  shims: true,  // Provides __dirname, __filename
+})
+```
+
+### require in ESM
+
+Auto-injected when `platform: 'node'`:
+
+```js
+// Generated:
+const require = createRequire(import.meta.url)
+```
+
+### ESM in CJS
+
+Always enabled - `import.meta.url`, `import.meta.dirname`, `import.meta.filename` work in CJS.
+
+### CJS Default Export
+
+When CJS output has only default export:
+
+```ts
+// Source
+export default function greet() {}
+
+// CJS Output
+module.exports = greet
+
+// Declaration
+declare function greet(): void
+export = greet
+```
+
+## Unbundle Mode
+
+Transpile-only - preserves file structure:
+
+```ts
+defineConfig({
+  entry: ['src/index.ts'],
+  unbundle: true,
+})
+```
+
+Input:
+
+```
+src/
+  index.ts
+  mod.ts
+```
+
+Output:
+
+```
+dist/
+  index.js
+  mod.js
+```
+
+## Watch Mode
+
+```ts
+defineConfig({
+  watch: true,
+  // Or specific paths
+  watch: ['./src', './lib'],
+})
+```
+
+```bash
+tsdown --watch
+tsdown --watch ./src
+tsdown --ignore-watch node_modules
+```
+
+### Post-Build Command
+
+```bash
+tsdown --watch --on-success "node dist/index.mjs"
+```
+
+## Copy Assets
+
+```bash
+tsdown --copy public
+```
+
+## Environment Variables
+
+```bash
+tsdown --env.NODE_ENV=production
+tsdown --env-file .env.production
+tsdown --env-prefix APP_
+```
+
+## Node Protocol
+
+Control Node.js built-in imports:
+
+```ts
+defineConfig({
+  nodeProtocol: true,     // fs → node:fs
+  nodeProtocol: 'strip',  // node:fs → fs
+  nodeProtocol: false,    // Keep as-is (default)
+})
+```
+
+## CSS
+
+```ts
+defineConfig({
+  css: {
+    splitting: false,      // Single CSS file
+    fileName: 'styles.css',
+  },
+})
+```
+
+CSS targeting (requires `unplugin-lightningcss`):
+
+```bash
+pnpm add -D unplugin-lightningcss
+```
+
+## JSX
+
+Built-in support via Rolldown:
+
+```ts
+defineConfig({
+  inputOptions: {
+    transform: {
+      jsx: 'react',  // Classic transform
+    },
+  },
+})
+```
+
+## Framework Support
+
+### React
+
+```ts
+// tsdown.config.ts
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  platform: 'neutral',
+  dts: true,
+})
+```
+
+React Compiler:
+
+```bash
+pnpm add -D @rollup/plugin-babel babel-plugin-react-compiler
+```
+
+```ts
+import pluginBabel from '@rollup/plugin-babel'
+
+defineConfig({
+  plugins: [
+    pluginBabel({
+      babelHelpers: 'bundled',
+      parserOpts: {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      },
+      plugins: ['babel-plugin-react-compiler'],
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    }),
+  ],
+})
+```
+
+### Vue
+
+```bash
+pnpm add -D unplugin-vue vue-tsc
+```
+
+```ts
+import { defineConfig } from 'tsdown'
+import Vue from 'unplugin-vue/rolldown'
+
+export default defineConfig({
+  entry: ['./src/index.ts'],
+  platform: 'neutral',
+  plugins: [Vue({ isProduction: true })],
+  dts: { vue: true },
+})
+```
+
+## Quick Start Templates
+
+```bash
+npx create-tsdown@latest -t vue
+npx create-tsdown@latest -t react
+npx create-tsdown@latest -t react-compiler
+```

--- a/skills/tsdown/references/output.md
+++ b/skills/tsdown/references/output.md
@@ -1,0 +1,260 @@
+# Output Options
+
+## Format
+
+Default: `esm`
+
+```ts
+defineConfig({
+  format: 'esm',                 // ECMAScript Modules
+  format: 'cjs',                 // CommonJS
+  format: 'iife',                // Browser script
+  format: 'umd',                 // Universal
+  format: ['esm', 'cjs'],        // Multiple
+})
+```
+
+Format-specific config:
+
+```ts
+defineConfig({
+  format: {
+    esm: { target: ['es2015'] },
+    cjs: { target: ['node20'] },
+  },
+})
+```
+
+## Output Directory
+
+```ts
+defineConfig({
+  outDir: 'dist',  // Default
+})
+```
+
+```bash
+tsdown -d ./build
+tsdown --out-dir ./build
+```
+
+## Target
+
+Syntax downleveling (no polyfills):
+
+```ts
+defineConfig({
+  target: 'es2020',
+  target: 'node20',
+  target: ['chrome100', 'firefox90'],
+})
+```
+
+Default: reads from `engines.node` in package.json.
+
+Disable transformations:
+
+```ts
+defineConfig({
+  target: false,  // Preserve modern syntax
+})
+```
+
+## Platform
+
+```ts
+defineConfig({
+  platform: 'node',     // Default, Node.js built-ins external
+  platform: 'browser',  // Web browsers
+  platform: 'neutral',  // Platform-agnostic
+})
+```
+
+Module resolution:
+
+- **node**: `mainFields: ['main', 'module']`
+- **browser**: `mainFields: ['browser', 'module', 'main']`
+- **neutral**: relies on `exports` field only
+
+## Declaration Files (.d.ts)
+
+```ts
+defineConfig({
+  dts: true,  // Enable
+})
+```
+
+Auto-enabled if `types` or `typings` in package.json.
+
+### Performance with isolatedDeclarations
+
+For fastest `.d.ts` generation:
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "isolatedDeclarations": true
+  }
+}
+```
+
+Uses oxc-transform instead of slower TypeScript.
+
+### Declaration Maps
+
+```ts
+defineConfig({
+  dts: {
+    sourcemap: true,  // .d.ts.map files
+  },
+})
+```
+
+Or via tsconfig.json:
+
+```json
+{
+  "compilerOptions": {
+    "declarationMap": true
+  }
+}
+```
+
+### Vue Support
+
+```ts
+defineConfig({
+  dts: { vue: true },  // Requires vue-tsc
+})
+```
+
+## Dependencies
+
+### Default Behavior
+
+| Type               | Bundled?          |
+| ------------------ | ----------------- |
+| `dependencies`     | No (external)     |
+| `peerDependencies` | No (external)     |
+| `devDependencies`  | Yes (if imported) |
+| Phantom deps       | Yes (if imported) |
+
+### Skip All node_modules
+
+```ts
+defineConfig({
+  skipNodeModulesBundle: true,
+})
+```
+
+### Custom External
+
+```ts
+defineConfig({
+  external: ['lodash', /^@my-scope\//],
+})
+```
+
+### Force Bundle
+
+```ts
+defineConfig({
+  noExternal: ['some-package'],  // Bundle despite being in deps
+})
+```
+
+## Package Exports
+
+Auto-generate `exports`, `main`, `module`, `types`:
+
+```ts
+defineConfig({
+  exports: true,
+})
+```
+
+### Export All Files
+
+```ts
+defineConfig({
+  exports: {
+    all: true,  // Not just entry files
+  },
+})
+```
+
+### Dev Exports
+
+Point to source during development:
+
+```ts
+defineConfig({
+  exports: {
+    devExports: true,
+  },
+})
+```
+
+`exports` → source, `publishConfig.exports` → built.
+
+### CSS Exports
+
+```ts
+defineConfig({
+  css: {
+    splitting: false,
+    fileName: 'my-library.css',
+  },
+  exports: true,
+})
+```
+
+### Custom Exports
+
+```ts
+defineConfig({
+  exports: {
+    customExports(pkg, context) {
+      pkg['./foo'] = './foo.js'
+      return pkg
+    },
+  },
+})
+```
+
+## Cleaning
+
+Output directory cleaned by default:
+
+```ts
+defineConfig({
+  clean: true,   // Default
+  clean: false,  // Keep existing
+})
+```
+
+## Example package.json
+
+```json
+{
+  "name": "my-lib",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": ["dist"]
+}
+```

--- a/skills/vite/SKILL.md
+++ b/skills/vite/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: vite
+description: Vite is a next-generation frontend build tool that provides a fast dev server with HMR and optimized production builds
+license: MIT
+---
+
+# Vite
+
+Next-gen frontend build tool with native ESM dev server and Rolldown-powered builds.
+
+## When to Use
+
+- Setting up frontend project build tooling
+- Configuring dev server, HMR, proxies
+- Building for production (SPA, MPA, library, SSR)
+- Writing Vite plugins
+- Integrating with backend frameworks
+
+## Quick Start
+
+```bash
+npm create vite@latest my-app
+```
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 3000,
+  },
+})
+```
+
+```bash
+vite          # Dev server
+vite build    # Production build
+vite preview  # Preview build
+```
+
+## Reference Files
+
+| Task                                    | File                                  |
+| --------------------------------------- | ------------------------------------- |
+| Config file, options, CLI, plugins      | [config.md](references/config.md)     |
+| ESM, CSS, assets, env vars, glob import | [features.md](references/features.md) |
+| Dev server, HMR, workers, performance   | [dev.md](references/dev.md)           |
+| Production, library mode, SSR, chunking | [build.md](references/build.md)       |
+| JS API, plugin authoring, module graph  | [advanced.md](references/advanced.md) |
+
+## Load Based on Task
+
+**Setting up a project?** → Load `config.md`
+**Using CSS/assets/env vars?** → Load `features.md`
+**Dev server issues?** → Load `dev.md`
+**Building for production?** → Load `build.md`
+**Writing plugins?** → Load `advanced.md`
+
+## Cross-Skill References
+
+- **Testing** → Use `vitest` skill (Vite-native testing)
+- **Vue projects** → Use `vue` skill for component patterns
+- **Library bundling** → Use `tsdown` skill for TypeScript libs

--- a/skills/vite/references/advanced.md
+++ b/skills/vite/references/advanced.md
@@ -1,0 +1,264 @@
+# Advanced
+
+## JavaScript API
+
+```ts
+import { createServer, build, preview, resolveConfig } from 'vite'
+
+// Dev server
+const server = await createServer({
+  configFile: false,
+  root: __dirname,
+  server: { port: 3000 },
+})
+await server.listen()
+server.printUrls()
+
+// Build
+await build({
+  root: './project',
+  build: { outDir: 'dist' },
+})
+
+// Preview
+const previewServer = await preview({
+  preview: { port: 4173, open: true },
+})
+
+// Resolve config
+const config = await resolveConfig({}, 'serve', 'development')
+```
+
+### ViteDevServer API
+
+```ts
+interface ViteDevServer {
+  config: ResolvedConfig
+  middlewares: Connect.Server      // Express-compatible
+  httpServer: http.Server | null
+  watcher: FSWatcher               // Chokidar
+  ws: WebSocketServer              // HMR WebSocket
+
+  transformRequest(url: string): Promise<TransformResult | null>
+  transformIndexHtml(url: string, html: string): Promise<string>
+  ssrLoadModule(url: string): Promise<Record<string, any>>
+  ssrFixStacktrace(e: Error): void
+
+  listen(port?: number): Promise<ViteDevServer>
+  restart(): Promise<void>
+  close(): Promise<void>
+}
+```
+
+### Utility Functions
+
+```ts
+import { mergeConfig, loadEnv, normalizePath, searchForWorkspaceRoot } from 'vite'
+
+// Merge configs
+const merged = mergeConfig(baseConfig, overrideConfig)
+
+// Load .env files
+const env = loadEnv('development', process.cwd(), 'VITE_')
+
+// Normalize Windows paths
+normalizePath('foo\\bar')  // 'foo/bar'
+
+// Find workspace root
+const root = searchForWorkspaceRoot(process.cwd())
+```
+
+## Plugin API
+
+```ts
+export default function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+
+    // Vite hooks
+    config(config, { command, mode }) {
+      return { /* merge into config */ }
+    },
+    configResolved(config) {
+      // Store resolved config
+    },
+    configureServer(server) {
+      // Add middleware
+      server.middlewares.use((req, res, next) => {
+        next()
+      })
+    },
+    transformIndexHtml(html) {
+      return html.replace('<title>', '<title>Modified ')
+    },
+    handleHotUpdate({ file, server, modules }) {
+      // Custom HMR
+    },
+
+    // Rolldown hooks
+    buildStart() {},
+    resolveId(id, importer) {},
+    load(id) {},
+    transform(code, id) {},
+    buildEnd() {},
+    closeBundle() {},
+  }
+}
+```
+
+### Virtual Modules
+
+```ts
+export default function virtualPlugin(): Plugin {
+  const virtualId = 'virtual:my-module'
+  const resolvedId = '\0' + virtualId
+
+  return {
+    name: 'virtual-module',
+    resolveId(id) {
+      if (id === virtualId) return resolvedId
+    },
+    load(id) {
+      if (id === resolvedId) {
+        return `export const data = ${JSON.stringify(buildTimeData)}`
+      }
+    },
+  }
+}
+```
+
+Usage:
+
+```ts
+import { data } from 'virtual:my-module'
+```
+
+### HTML Injection
+
+```ts
+export default function injectPlugin(): Plugin {
+  return {
+    name: 'inject-tags',
+    transformIndexHtml() {
+      return {
+        tags: [
+          {
+            tag: 'script',
+            attrs: { src: '/inject.js' },
+            injectTo: 'body',  // 'head' | 'body' | 'head-prepend' | 'body-prepend'
+          },
+        ],
+      }
+    },
+  }
+}
+```
+
+### Client-Server Communication
+
+```ts
+// Plugin (server)
+configureServer(server) {
+  server.ws.on('my:event', (data, client) => {
+    client.send('my:reply', { received: true })
+  })
+}
+
+// Client
+if (import.meta.hot) {
+  import.meta.hot.send('my:event', { message: 'hello' })
+  import.meta.hot.on('my:reply', (data) => {
+    console.log(data)
+  })
+}
+```
+
+### Transform Filtering
+
+```ts
+{
+  transform: {
+    filter: { id: /\.vue$/ },
+    handler(code, id) {
+      return transformVue(code)
+    },
+  },
+}
+```
+
+## Plugin Ordering
+
+```ts
+export default function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+    enforce: 'pre',   // Run before core plugins
+    // enforce: 'post' - Run after core plugins
+    // No enforce - Run with user plugins
+  }
+}
+```
+
+## Conditional Plugins
+
+```ts
+export default function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+    apply: 'serve',   // Only in dev
+    // apply: 'build' - Only in production
+    // apply: (config, { command }) => command === 'serve'
+  }
+}
+```
+
+## Performance Optimization
+
+### Browser Setup
+
+- Use dev-only browser profile
+- Disable DevTools "Disable Cache"
+- Disable browser extensions
+
+### Plugin Performance
+
+1. Lazy load heavy dependencies
+2. Avoid long operations in `buildStart`, `config`, `configResolved`
+3. Check file extension before processing in `transform`
+
+### Build Performance
+
+```ts
+defineConfig({
+  build: {
+    reportCompressedSize: false,  // Skip gzip calculation
+    sourcemap: false,
+  },
+})
+```
+
+### Debug
+
+```bash
+vite --debug plugin-transform    # Transform timing
+vite --profile                   # CPU profile → speedscope
+```
+
+## Named Plugin Conventions
+
+- `vite-plugin-*` - Vite-specific
+- `rollup-plugin-*` - Rollup-compatible
+- `vite-plugin-vue-*` - Vue-specific
+- `vite-plugin-react-*` - React-specific
+
+## Module Graph
+
+Access module dependency graph:
+
+```ts
+configureServer(server) {
+  server.moduleGraph.getModuleById(id)
+  server.moduleGraph.getModulesByFile(file)
+  server.moduleGraph.invalidateModule(mod)
+}
+```

--- a/skills/vite/references/build.md
+++ b/skills/vite/references/build.md
@@ -1,0 +1,251 @@
+# Build
+
+## Production Build
+
+```bash
+vite build
+```
+
+```ts
+defineConfig({
+  build: {
+    outDir: 'dist',
+    assetsDir: 'assets',
+    target: 'modules',              // ESM browsers
+    minify: 'esbuild',              // or 'terser'
+    cssMinify: true,
+    sourcemap: false,               // true, 'inline', 'hidden'
+    emptyOutDir: true,
+    reportCompressedSize: true,     // false for faster builds
+
+    // Chunk size warnings
+    chunkSizeWarningLimit: 500,
+  },
+})
+```
+
+## Multi-Page App
+
+```ts
+defineConfig({
+  build: {
+    rolldownOptions: {
+      input: {
+        main: 'index.html',
+        nested: 'nested/index.html',
+      },
+    },
+  },
+})
+```
+
+## Library Mode
+
+```ts
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'MyLib',
+      fileName: 'my-lib',          // → my-lib.es.js, my-lib.umd.js
+      formats: ['es', 'umd'],
+    },
+    rolldownOptions: {
+      external: ['vue', 'react'],  // Don't bundle
+      output: {
+        globals: {
+          vue: 'Vue',
+          react: 'React',
+        },
+      },
+    },
+  },
+})
+```
+
+### package.json for Library
+
+```json
+{
+  "name": "my-lib",
+  "type": "module",
+  "main": "./dist/my-lib.umd.cjs",
+  "module": "./dist/my-lib.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/my-lib.js",
+      "require": "./dist/my-lib.umd.cjs"
+    }
+  },
+  "files": ["dist"]
+}
+```
+
+## SSR Build
+
+```ts
+defineConfig({
+  build: {
+    ssr: true,                      // or 'src/entry-server.ts'
+    ssrEmitAssets: true,
+  },
+})
+```
+
+### SSR Entry
+
+```ts
+// src/entry-server.ts
+import { renderToString } from 'vue/server-renderer'
+import { createApp } from './main'
+
+export async function render(url: string) {
+  const { app, router } = createApp()
+  await router.push(url)
+  await router.isReady()
+  const html = await renderToString(app)
+  return { html }
+}
+```
+
+### Server Integration
+
+```ts
+import express from 'express'
+import { createServer as createViteServer } from 'vite'
+
+const app = express()
+
+const vite = await createViteServer({
+  server: { middlewareMode: true },
+  appType: 'custom',
+})
+
+app.use(vite.middlewares)
+
+app.use('*', async (req, res) => {
+  // 1. Read index.html
+  let template = fs.readFileSync('index.html', 'utf-8')
+
+  // 2. Apply Vite transforms
+  template = await vite.transformIndexHtml(req.url, template)
+
+  // 3. Load SSR entry
+  const { render } = await vite.ssrLoadModule('/src/entry-server.ts')
+
+  // 4. Render
+  const { html } = await render(req.url)
+
+  // 5. Inject
+  const page = template.replace('<!--ssr-outlet-->', html)
+  res.send(page)
+})
+```
+
+### SSR Externals
+
+```ts
+defineConfig({
+  ssr: {
+    external: ['lodash'],           // Don't bundle
+    noExternal: ['@my/ui-lib'],     // Bundle despite node_modules
+  },
+})
+```
+
+## Backend Integration
+
+For traditional backends (Rails, Laravel, etc.):
+
+```ts
+defineConfig({
+  server: {
+    cors: { origin: 'http://my-backend.example.com' },
+  },
+  build: {
+    manifest: true,                 // Generate manifest.json
+    rolldownOptions: {
+      input: '/path/to/main.js',
+    },
+  },
+})
+```
+
+Manifest output (`.vite/manifest.json`):
+
+```json
+{
+  "views/foo.js": {
+    "file": "assets/foo-abc123.js",
+    "src": "views/foo.js",
+    "isEntry": true,
+    "imports": ["_shared-def456.js"],
+    "css": ["assets/foo-789abc.css"]
+  }
+}
+```
+
+Use manifest to generate correct `<script>` and `<link>` tags in backend templates.
+
+## Chunking Strategies
+
+```ts
+defineConfig({
+  build: {
+    rolldownOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['vue', 'vue-router', 'pinia'],
+          ui: ['@ui/components'],
+        },
+
+        // Or function for dynamic chunking
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return 'vendor'
+          }
+        },
+      },
+    },
+  },
+})
+```
+
+## Asset Handling
+
+```ts
+defineConfig({
+  build: {
+    assetsInlineLimit: 4096,        // Inline < 4KB
+    rolldownOptions: {
+      output: {
+        assetFileNames: 'assets/[name]-[hash][extname]',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        entryFileNames: 'entries/[name]-[hash].js',
+      },
+    },
+  },
+})
+```
+
+## Legacy Browser Support
+
+```bash
+npm i -D @vitejs/plugin-legacy
+```
+
+```ts
+import legacy from '@vitejs/plugin-legacy'
+
+defineConfig({
+  plugins: [
+    legacy({
+      targets: ['defaults', 'not IE 11'],
+    }),
+  ],
+})
+```

--- a/skills/vite/references/config.md
+++ b/skills/vite/references/config.md
@@ -1,0 +1,224 @@
+# Configuration & CLI
+
+## Config File
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  // options
+})
+```
+
+Conditional config:
+
+```ts
+export default defineConfig(({ command, mode }) => {
+  if (command === 'serve') {
+    return { /* dev config */ }
+  }
+  return { /* build config */ }
+})
+```
+
+Async config:
+
+```ts
+export default defineConfig(async ({ command }) => {
+  const data = await fetchConfig()
+  return { define: { CONFIG: data } }
+})
+```
+
+## Common Options
+
+```ts
+defineConfig({
+  root: './',                    // Project root
+  base: '/',                     // Public base path
+  publicDir: 'public',           // Static assets dir
+  cacheDir: 'node_modules/.vite',
+
+  // Dependency pre-bundling
+  optimizeDeps: {
+    include: ['lodash-es'],
+    exclude: ['@my/package'],
+    force: true,  // Re-bundle on restart
+  },
+
+  // Path resolution
+  resolve: {
+    alias: {
+      '@': '/src',
+      '~': '/src',
+    },
+    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx'],
+    mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
+  },
+
+  // Module handling
+  json: {
+    stringify: true,  // Smaller bundles
+  },
+
+  // Log level
+  logLevel: 'info',  // 'info', 'warn', 'error', 'silent'
+})
+```
+
+## Server Options
+
+```ts
+defineConfig({
+  server: {
+    host: '0.0.0.0',
+    port: 3000,
+    strictPort: true,
+    open: true,
+    https: true,
+    cors: true,
+
+    // Proxy API requests
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+      '/socket.io': {
+        target: 'ws://localhost:8080',
+        ws: true,
+      },
+    },
+
+    // File system access
+    fs: {
+      strict: true,
+      allow: ['..'],
+      deny: ['.env', '.env.*'],
+    },
+
+    // Warmup frequently used files
+    warmup: {
+      clientFiles: ['./src/main.ts', './src/App.vue'],
+      ssrFiles: ['./src/server/entry.ts'],
+    },
+
+    // File watching
+    watch: {
+      ignored: ['**/large-folder/**'],
+    },
+  },
+})
+```
+
+## Build Options
+
+```ts
+defineConfig({
+  build: {
+    outDir: 'dist',
+    assetsDir: 'assets',
+    target: 'es2020',            // 'esnext', 'es2015', etc.
+    minify: 'esbuild',           // 'esbuild', 'terser', false
+    cssMinify: true,
+    sourcemap: true,             // true, 'inline', 'hidden'
+    emptyOutDir: true,
+
+    // Chunking
+    rolldownOptions: {
+      input: {
+        main: 'src/main.ts',
+        admin: 'src/admin.ts',
+      },
+      output: {
+        manualChunks: {
+          vendor: ['vue', 'vue-router'],
+        },
+      },
+    },
+
+    // Inline threshold
+    assetsInlineLimit: 4096,
+
+    // Module format
+    modulePreload: { polyfill: true },
+  },
+})
+```
+
+## Preview Options
+
+```ts
+defineConfig({
+  preview: {
+    port: 4173,
+    host: true,
+    strictPort: true,
+    open: true,
+    proxy: { /* same as server.proxy */ },
+  },
+})
+```
+
+## Plugins
+
+```ts
+import vue from '@vitejs/plugin-vue'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    react(),
+    // Conditional plugin
+    process.env.ANALYZE && analyzePlugin(),
+  ],
+})
+```
+
+Official plugins:
+
+- `@vitejs/plugin-vue` - Vue 3 SFC
+- `@vitejs/plugin-vue-jsx` - Vue 3 JSX
+- `@vitejs/plugin-react` - React Fast Refresh
+- `@vitejs/plugin-legacy` - Legacy browser support
+
+Community plugins: [awesome-vite](https://github.com/vitejs/awesome-vite)
+
+## CLI Commands
+
+```bash
+vite                    # Dev server
+vite build              # Production build
+vite preview            # Preview production build
+vite optimize           # Pre-bundle dependencies
+
+# Options
+--config <file>         # Config file path
+--base <path>           # Public base path
+--mode <mode>           # Set mode (development, production)
+--port <port>           # Server port
+--host                  # Expose to network
+--open [path]           # Open browser
+--force                 # Force dependency re-bundling
+--cors                  # Enable CORS
+--strictPort            # Exit if port taken
+--debug [feat]          # Debug logs
+--profile               # CPU profiling
+```
+
+## Package.json Scripts
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "build:analyze": "vite build --mode analyze"
+  }
+}
+```

--- a/skills/vite/references/dev.md
+++ b/skills/vite/references/dev.md
@@ -1,0 +1,253 @@
+# Development
+
+## Dev Server Features
+
+- Native ESM serving (no bundling in dev)
+- Instant HMR (Hot Module Replacement)
+- TypeScript transpilation
+- CSS HMR
+- Vue/React/Svelte SFC support
+
+## Dependency Pre-Bundling
+
+Vite pre-bundles dependencies for:
+
+- CommonJS to ESM conversion
+- Many-module dependencies (lodash-es)
+- Faster cold starts
+
+```ts
+defineConfig({
+  optimizeDeps: {
+    include: [
+      'lodash-es',              // Pre-bundle specific deps
+      'vue > @vue/runtime-dom', // Nested deps
+    ],
+    exclude: ['@my/local-pkg'], // Skip pre-bundling
+    force: true,                // Re-bundle on restart
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
+})
+```
+
+Auto-discovery runs on server start. Use `--force` to re-bundle.
+
+## File System Access
+
+```ts
+defineConfig({
+  server: {
+    fs: {
+      strict: true,            // Only allow listed dirs
+      allow: [
+        '../shared',           // Allow parent directory
+        searchForWorkspaceRoot(process.cwd()),  // Monorepo root
+      ],
+      deny: ['.env', '.env.*', '*.pem'],
+    },
+  },
+})
+```
+
+## HMR Configuration
+
+```ts
+defineConfig({
+  server: {
+    hmr: {
+      overlay: true,           // Error overlay
+      port: 24678,             // WebSocket port
+      protocol: 'ws',          // 'ws' or 'wss'
+      host: 'localhost',
+      clientPort: 443,         // For reverse proxy
+    },
+  },
+})
+```
+
+Disable HMR:
+
+```ts
+defineConfig({
+  server: {
+    hmr: false,
+  },
+})
+```
+
+## HMR API Usage
+
+```ts
+// Basic accept
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}
+
+// Accept with handler
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    // Handle update
+  })
+}
+
+// Preserve state
+let count = import.meta.hot?.data?.count ?? 0
+
+if (import.meta.hot) {
+  import.meta.hot.dispose((data) => {
+    data.count = count
+  })
+  import.meta.hot.accept()
+}
+
+// Custom events (plugin communication)
+if (import.meta.hot) {
+  import.meta.hot.on('custom:event', (payload) => {
+    console.log(payload)
+  })
+}
+```
+
+## Web Workers
+
+```ts
+// Constructor (recommended)
+const worker = new Worker(
+  new URL('./worker.ts', import.meta.url),
+  { type: 'module' }
+)
+
+// Query suffix
+import MyWorker from './worker?worker'
+const worker = new MyWorker()
+
+// Inline (bundled, no separate file)
+import InlineWorker from './worker?worker&inline'
+```
+
+Worker file:
+
+```ts
+// worker.ts
+self.onmessage = (e: MessageEvent) => {
+  const result = heavyComputation(e.data)
+  self.postMessage(result)
+}
+```
+
+SharedWorker:
+
+```ts
+import SharedWorker from './shared?sharedworker'
+const worker = new SharedWorker()
+```
+
+## Watch Mode
+
+```ts
+defineConfig({
+  server: {
+    watch: {
+      usePolling: true,        // For network drives, containers
+      interval: 100,
+      ignored: ['**/node_modules/**', '**/.git/**'],
+    },
+  },
+})
+```
+
+## HTTPS
+
+```ts
+import basicSsl from '@vitejs/plugin-basic-ssl'
+
+defineConfig({
+  plugins: [basicSsl()],
+  server: {
+    https: true,
+  },
+})
+```
+
+Custom certificates:
+
+```ts
+import fs from 'node:fs'
+
+defineConfig({
+  server: {
+    https: {
+      key: fs.readFileSync('localhost-key.pem'),
+      cert: fs.readFileSync('localhost.pem'),
+    },
+  },
+})
+```
+
+## Network Access
+
+```bash
+vite --host                    # Expose to network
+vite --host 0.0.0.0            # Specific interface
+```
+
+```ts
+defineConfig({
+  server: {
+    host: true,                // Same as --host
+    port: 3000,
+    strictPort: true,          // Fail if port taken
+  },
+})
+```
+
+## Performance Tips
+
+1. **Explicit file extensions** - Reduce resolve operations
+
+   ```ts
+   import './Component.tsx'  // Instead of './Component'
+   ```
+
+2. **Warm up frequently used files**
+
+   ```ts
+   server: {
+     warmup: {
+       clientFiles: ['./src/main.ts', './src/App.vue'],
+     },
+   }
+   ```
+
+3. **Avoid barrel files** - Direct imports are faster
+
+   ```ts
+   import { util } from './utils/util.ts'  // Not './utils'
+   ```
+
+4. **Limit watched files**
+
+   ```ts
+   server: {
+     watch: {
+       ignored: ['**/large-folder/**'],
+     },
+   }
+   ```
+
+5. **Disable unused features**
+   ```ts
+   css: { devSourcemap: false }
+   ```
+
+## Profiling
+
+```bash
+vite --debug                   # Debug logs
+vite --debug plugin-transform  # Transform times
+vite --profile                 # CPU profile
+```
+
+Use [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect) for plugin debugging.

--- a/skills/vite/references/features.md
+++ b/skills/vite/references/features.md
@@ -1,0 +1,261 @@
+# Features
+
+## Native ESM Imports
+
+Vite serves source files directly via native ES modules in dev.
+
+```ts
+// Bare imports resolved from node_modules
+import _ from 'lodash'
+
+// Relative imports
+import { util } from './utils'
+
+// Absolute paths from project root
+import App from '/src/App.vue'
+```
+
+## TypeScript Support
+
+Native TypeScript support - no config needed.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    target: 'esnext',
+    jsxFactory: 'h',
+    jsxFragment: 'Fragment',
+  },
+})
+```
+
+Type checking is transpile-only. Run `vue-tsc` or `tsc --noEmit` separately.
+
+## CSS
+
+### CSS Modules
+
+```css
+/* styles.module.css */
+.red { color: red; }
+```
+
+```ts
+import classes from './styles.module.css'
+console.log(classes.red)
+```
+
+### Preprocessors
+
+Install the preprocessor:
+
+```bash
+npm i -D sass less stylus
+```
+
+```vue
+<style lang="scss">
+$color: red;
+.btn { color: $color; }
+</style>
+```
+
+### PostCSS
+
+Create `postcss.config.js`:
+
+```js
+export default {
+  plugins: {
+    autoprefixer: {},
+    'tailwindcss/nesting': {},
+    tailwindcss: {},
+  },
+}
+```
+
+### Lightning CSS
+
+```ts
+defineConfig({
+  css: {
+    transformer: 'lightningcss',
+    lightningcss: {
+      targets: { chrome: 80 },
+    },
+  },
+})
+```
+
+## Static Assets
+
+```ts
+// URL (dev: raw path, build: hashed)
+import imgUrl from './img.png'
+img.src = imgUrl
+
+// Raw content
+import text from './file.txt?raw'
+
+// As URL (for workers)
+import workerUrl from './worker.js?url'
+
+// Inline as base64
+import dataUrl from './small.png?inline'
+```
+
+### public Directory
+
+Files in `public/` served at root, not processed.
+
+```html
+<img src="/logo.png" />
+```
+
+## JSON
+
+```ts
+// Full import
+import pkg from './package.json'
+
+// Named imports (tree-shaken)
+import { version } from './package.json'
+```
+
+## Glob Import
+
+```ts
+// Eager load all
+const modules = import.meta.glob('./modules/*.ts', { eager: true })
+
+// Lazy load (dynamic import)
+const modules = import.meta.glob('./modules/*.ts')
+for (const path in modules) {
+  const mod = await modules[path]()
+}
+
+// With options
+const modules = import.meta.glob('./modules/*.ts', {
+  import: 'default',           // Named export
+  query: { raw: true },        // Query params
+  exhaustive: true,            // Include node_modules
+})
+
+// Negative patterns
+const modules = import.meta.glob(['./dir/*.ts', '!**/ignored.ts'])
+
+// As strings
+const modules = import.meta.glob('./modules/*.ts', {
+  query: '?raw',
+  import: 'default',
+})
+```
+
+## Environment Variables
+
+### .env Files
+
+```ini
+# .env
+VITE_APP_TITLE=My App
+VITE_API_URL=http://api.example.com
+```
+
+Load order: `.env` < `.env.local` < `.env.[mode]` < `.env.[mode].local`
+
+### Usage
+
+```ts
+console.log(import.meta.env.VITE_APP_TITLE)
+console.log(import.meta.env.MODE)       // 'development' | 'production'
+console.log(import.meta.env.DEV)        // boolean
+console.log(import.meta.env.PROD)       // boolean
+console.log(import.meta.env.SSR)        // boolean
+console.log(import.meta.env.BASE_URL)   // base path
+```
+
+### TypeScript Types
+
+```ts
+// env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_TITLE: string
+  readonly VITE_API_URL: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+```
+
+### Define at Build Time
+
+```ts
+defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify('1.0.0'),
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+  },
+})
+```
+
+## HMR API
+
+```ts
+if (import.meta.hot) {
+  // Accept self
+  import.meta.hot.accept()
+
+  // Accept deps
+  import.meta.hot.accept('./module.js', (newModule) => {
+    console.log('module updated', newModule)
+  })
+
+  // Dispose handler
+  import.meta.hot.dispose((data) => {
+    cleanup()
+  })
+
+  // Preserve data across updates
+  import.meta.hot.data.count = count
+
+  // Custom events
+  import.meta.hot.on('my-event', (data) => {})
+  import.meta.hot.send('my-event', data)
+
+  // Invalidate and trigger re-import
+  import.meta.hot.invalidate()
+
+  // Decline HMR (full reload)
+  import.meta.hot.decline()
+}
+```
+
+## Web Workers
+
+```ts
+// Constructor pattern
+const worker = new Worker(new URL('./worker.ts', import.meta.url))
+
+// Import suffix
+import MyWorker from './worker?worker'
+const worker = new MyWorker()
+
+// Inline (no file)
+import InlineWorker from './worker?worker&inline'
+
+// Shared worker
+import SharedWorker from './worker?sharedworker'
+```
+
+```ts
+// worker.ts
+self.onmessage = (e) => {
+  self.postMessage(e.data * 2)
+}
+```

--- a/skills/vitest/SKILL.md
+++ b/skills/vitest/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: vitest
+description: A blazing fast unit testing framework powered by Vite
+license: MIT
+---
+
+# Vitest
+
+Vite-native testing framework with Jest-compatible API.
+
+## When to Use
+
+- Writing unit/integration tests for Vite projects
+- Testing Vue/React/Svelte components
+- Mocking modules, timers, or dates
+- Running concurrent/parallel tests
+- Type testing with TypeScript
+
+## Quick Start
+
+```bash
+npm i -D vitest
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',  // or 'jsdom' for DOM tests
+  },
+})
+```
+
+```ts
+// example.test.ts
+import { describe, expect, it, vi } from 'vitest'
+
+describe('math', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2)
+  })
+})
+```
+
+## Reference Files
+
+| Task                                     | File                                    |
+| ---------------------------------------- | --------------------------------------- |
+| Configuration, CLI, projects             | [config.md](references/config.md)       |
+| test/describe, hooks, fixtures           | [test-api.md](references/test-api.md)   |
+| vi.fn, vi.mock, timers, spies            | [mocking.md](references/mocking.md)     |
+| expect, snapshots, coverage, filtering   | [utilities.md](references/utilities.md) |
+| Environments, type testing, browser mode | [advanced.md](references/advanced.md)   |
+
+## Load Based on Task
+
+**Setting up tests?** → Load `config.md`
+**Writing test cases?** → Load `test-api.md`
+**Mocking dependencies?** → Load `mocking.md`
+**Assertions/snapshots?** → Load `utilities.md`
+**DOM/browser/types?** → Load `advanced.md`
+
+## Cross-Skill References
+
+- **Vue component testing** → Use `vue` skill for component patterns
+- **Library testing** → Use `ts-library` skill for library patterns
+- **Vite configuration** → Use `vite` skill for shared config

--- a/skills/vitest/references/advanced.md
+++ b/skills/vitest/references/advanced.md
@@ -1,0 +1,258 @@
+# Advanced
+
+## Test Environments
+
+Available: `node` (default), `jsdom`, `happy-dom`, `edge-runtime`
+
+```ts
+defineConfig({
+  test: {
+    environment: 'jsdom',
+    environmentOptions: {
+      jsdom: { url: 'http://localhost' },
+    },
+  },
+})
+```
+
+Install packages:
+
+```bash
+npm i -D jsdom       # Full browser simulation
+npm i -D happy-dom   # Faster, fewer APIs
+```
+
+Per-file environment:
+
+```ts
+// @vitest-environment jsdom
+
+test('DOM test', () => {
+  const div = document.createElement('div')
+  expect(div).toBeInstanceOf(HTMLDivElement)
+})
+```
+
+Multiple environments via projects:
+
+```ts
+defineConfig({
+  test: {
+    projects: [
+      { test: { name: 'unit', include: ['tests/unit/**'], environment: 'node' } },
+      { test: { name: 'dom', include: ['tests/dom/**'], environment: 'jsdom' } },
+    ],
+  },
+})
+```
+
+### Custom Environment
+
+```ts
+// vitest-environment-custom/index.ts
+import type { Environment } from 'vitest/runtime'
+
+export default <Environment>{
+  name: 'custom',
+  viteEnvironment: 'ssr',
+  setup() {
+    globalThis.myGlobal = 'value'
+    return {
+      teardown() { delete globalThis.myGlobal },
+    }
+  },
+}
+```
+
+## Type Testing
+
+Test TypeScript types with `.test-d.ts` files:
+
+```ts
+// math.test-d.ts
+import { expectTypeOf } from 'vitest'
+import { add } from './math'
+
+test('add returns number', () => {
+  expectTypeOf(add).returns.toBeNumber()
+})
+```
+
+### expectTypeOf API
+
+```ts
+// Basic types
+expectTypeOf<string>().toBeString()
+expectTypeOf<number>().toBeNumber()
+expectTypeOf<boolean>().toBeBoolean()
+expectTypeOf<null>().toBeNull()
+expectTypeOf<undefined>().toBeUndefined()
+expectTypeOf<never>().toBeNever()
+expectTypeOf<any>().toBeAny()
+expectTypeOf<unknown>().toBeUnknown()
+expectTypeOf<[]>().toBeArray()
+expectTypeOf<Function>().toBeFunction()
+
+// Value types
+const value = 'hello'
+expectTypeOf(value).toBeString()
+expectTypeOf(obj).toMatchTypeOf<{ name: string }>()
+expectTypeOf(obj).toHaveProperty('name')
+
+// Functions
+expectTypeOf(greet).parameters.toEqualTypeOf<[string]>()
+expectTypeOf(greet).returns.toBeString()
+expectTypeOf(greet).parameter(0).toBeString()
+
+// Equality
+expectTypeOf<B>().toMatchTypeOf<A>()     // Subset matching
+expectTypeOf<A>().toEqualTypeOf<B>()     // Exact match
+expectTypeOf<A>().not.toEqualTypeOf<B>()
+
+// Nullable
+expectTypeOf<string | null>().toBeNullable()
+```
+
+### assertType
+
+```ts
+import { assertType } from 'vitest'
+
+// @ts-expect-error - should fail type check
+assertType<string>(result)
+
+assertType<User | null>(result)  // Correct
+```
+
+Run: `vitest typecheck` or `vitest --typecheck`
+
+## Projects (Workspaces)
+
+```ts
+defineConfig({
+  test: {
+    projects: [
+      'packages/*',  // Glob for package configs
+      {
+        test: {
+          name: 'unit',
+          include: ['tests/unit/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
+    ],
+  },
+})
+```
+
+### Providing Values
+
+```ts
+defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'staging',
+          provide: { apiUrl: 'https://staging.api.com' },
+        },
+      },
+    ],
+  },
+})
+
+// In tests
+import { inject } from 'vitest'
+const url = inject('apiUrl')
+```
+
+### Running Specific Projects
+
+```bash
+vitest --project unit
+vitest --project unit --project e2e
+vitest --project.ignore browser
+```
+
+## Browser Mode
+
+Real browser testing (separate from environments):
+
+```ts
+defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      name: 'chromium',  // or 'firefox', 'webkit'
+      provider: 'playwright',
+    },
+  },
+})
+```
+
+## CSS in Tests
+
+```ts
+defineConfig({
+  test: {
+    css: true,
+    // Or with options
+    css: {
+      include: /\.module\.css$/,
+      modules: { classNameStrategy: 'non-scoped' },
+    },
+  },
+})
+```
+
+## External Dependencies
+
+Fix deps that fail with CSS/asset errors:
+
+```ts
+defineConfig({
+  test: {
+    server: {
+      deps: {
+        inline: ['problematic-package'],
+      },
+    },
+  },
+})
+```
+
+## Global Setup
+
+```ts
+defineConfig({
+  test: {
+    globalSetup: ['./tests/global-setup.ts'],
+  },
+})
+
+// tests/global-setup.ts
+export default async function setup() {
+  // Run before all tests
+  return async () => {
+    // Teardown after all tests
+  }
+}
+```
+
+## Benchmarking
+
+```ts
+import { bench, describe } from 'vitest'
+
+describe('sort', () => {
+  bench('native', () => {
+    [1, 5, 4, 2, 3].sort((a, b) => a - b)
+  })
+
+  bench('lodash', () => {
+    _.sortBy([1, 5, 4, 2, 3])
+  })
+})
+```
+
+Run: `vitest bench`

--- a/skills/vitest/references/config.md
+++ b/skills/vitest/references/config.md
@@ -1,0 +1,173 @@
+# Configuration & CLI
+
+## Config File Setup
+
+Vitest reads from `vitest.config.ts` or `vite.config.ts`.
+
+```ts
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // test options
+  },
+})
+```
+
+With existing Vite config:
+
+```ts
+// vite.config.ts
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+})
+```
+
+Merge configs:
+
+```ts
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(viteConfig, defineConfig({
+  test: { environment: 'jsdom' },
+}))
+```
+
+## Common Options
+
+```ts
+defineConfig({
+  test: {
+    globals: true,                    // Enable global APIs without imports
+    environment: 'node',              // 'node', 'jsdom', 'happy-dom'
+    setupFiles: ['./tests/setup.ts'], // Run before each test file
+    include: ['**/*.{test,spec}.{js,ts,jsx,tsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    testTimeout: 5000,
+    hookTimeout: 10000,
+    watch: true,
+    coverage: {
+      provider: 'v8',                 // or 'istanbul'
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts'],
+    },
+    isolate: true,                    // Each file in separate process
+    pool: 'threads',                  // 'threads', 'forks', 'vmThreads'
+    poolOptions: {
+      threads: { maxThreads: 4, minThreads: 1 },
+    },
+    clearMocks: true,
+    restoreMocks: true,
+    retry: 0,
+    bail: 0,
+  },
+})
+```
+
+## Conditional Config
+
+```ts
+export default defineConfig(({ mode }) => ({
+  plugins: mode === 'test' ? [] : [myPlugin()],
+  test: { /* options */ },
+}))
+```
+
+## Projects (Monorepos)
+
+```ts
+defineConfig({
+  test: {
+    projects: [
+      'packages/*',
+      {
+        test: {
+          name: 'unit',
+          include: ['tests/unit/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          include: ['tests/integration/**/*.test.ts'],
+          environment: 'jsdom',
+        },
+      },
+    ],
+  },
+})
+```
+
+## CLI Commands
+
+```bash
+vitest                    # Watch mode in dev, run mode in CI
+vitest run                # Single run without watch
+vitest run --coverage     # With coverage
+vitest related src/index.ts --run  # Tests importing specific files
+vitest bench              # Benchmark tests only
+vitest list --json        # List tests without running
+vitest typecheck          # Type tests only
+```
+
+## Common CLI Options
+
+```bash
+--config <path>           # Config file path
+--project <name>          # Run specific project
+-t, --testNamePattern     # Filter by test name
+--changed                 # Only changed files
+--changed HEAD~1          # Since last commit
+--reporter <name>         # default, verbose, dot, json, html
+--coverage                # Enable coverage
+--shard <index>/<count>   # Split across machines
+--bail <n>                # Stop after n failures
+--retry <n>               # Retry failed tests
+--environment <env>       # jsdom, happy-dom, node
+--globals                 # Enable global APIs
+--inspect                 # Node inspector
+--silent                  # Suppress output
+```
+
+## Sharding for CI
+
+```bash
+# Split across 3 machines
+vitest run --shard=1/3 --reporter=blob
+vitest run --shard=2/3 --reporter=blob
+vitest run --shard=3/3 --reporter=blob
+
+# Merge reports
+vitest --merge-reports --reporter=junit
+```
+
+## Watch Mode Shortcuts
+
+- `a` - Run all tests
+- `f` - Run only failed
+- `u` - Update snapshots
+- `p` - Filter by filename
+- `t` - Filter by test name
+- `q` - Quit
+
+## Package.json Scripts
+
+```json
+{
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:ui": "vitest --ui",
+    "coverage": "vitest run --coverage"
+  }
+}
+```

--- a/skills/vitest/references/mocking.md
+++ b/skills/vitest/references/mocking.md
@@ -1,0 +1,243 @@
+# Mocking
+
+## Mock Functions
+
+```ts
+import { vi } from 'vitest'
+
+const fn = vi.fn()
+fn('hello')
+
+expect(fn).toHaveBeenCalled()
+expect(fn).toHaveBeenCalledWith('hello')
+
+// With implementation
+const add = vi.fn((a, b) => a + b)
+expect(add(1, 2)).toBe(3)
+
+// Mock return values
+fn.mockReturnValue(42)
+fn.mockReturnValueOnce(1).mockReturnValueOnce(2)
+fn.mockResolvedValue({ data: true })
+fn.mockRejectedValue(new Error('fail'))
+fn.mockImplementation((x) => x * 2)
+fn.mockImplementationOnce(() => 'first call')
+```
+
+## Spying
+
+```ts
+const cart = { getTotal: () => 100 }
+
+const spy = vi.spyOn(cart, 'getTotal')
+cart.getTotal()
+
+expect(spy).toHaveBeenCalled()
+spy.mockReturnValue(200)
+spy.mockRestore()  // Restore original
+
+// Spy on getter/setter
+vi.spyOn(obj, 'prop', 'get').mockReturnValue('value')
+```
+
+## Module Mocking
+
+```ts
+// vi.mock is hoisted to top of file
+vi.mock('./api', () => ({
+  fetchUser: vi.fn(() => ({ id: 1, name: 'Mock' })),
+}))
+
+import { fetchUser } from './api'
+
+test('mocked module', () => {
+  expect(fetchUser()).toEqual({ id: 1, name: 'Mock' })
+})
+```
+
+### Partial Mock
+
+```ts
+vi.mock('./utils', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    specificFunction: vi.fn(),
+  }
+})
+```
+
+### Auto-mock with Spy
+
+```ts
+vi.mock('./calculator', { spy: true })
+
+import { add } from './calculator'
+
+test('spy on module', () => {
+  const result = add(1, 2)  // Real implementation
+  expect(result).toBe(3)
+  expect(add).toHaveBeenCalledWith(1, 2)
+})
+```
+
+### Manual Mocks (**mocks**)
+
+```
+src/
+  __mocks__/
+    axios.ts      # Mocks 'axios'
+  api/
+    __mocks__/
+      client.ts   # Mocks './client'
+    client.ts
+```
+
+```ts
+vi.mock('axios')
+vi.mock('./api/client')
+```
+
+## Dynamic Mocking (vi.doMock)
+
+Not hoisted - for dynamic imports:
+
+```ts
+test('dynamic mock', async () => {
+  vi.doMock('./config', () => ({ apiUrl: 'http://test.local' }))
+  const { apiUrl } = await import('./config')
+  expect(apiUrl).toBe('http://test.local')
+  vi.doUnmock('./config')
+})
+```
+
+## Hoisted Variables
+
+```ts
+const mockFn = vi.hoisted(() => vi.fn())
+
+vi.mock('./module', () => ({
+  getData: mockFn,
+}))
+
+test('hoisted mock', () => {
+  mockFn.mockReturnValue('test')
+  expect(getData()).toBe('test')
+})
+```
+
+## Mock Timers
+
+```ts
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+test('timers', () => {
+  const fn = vi.fn()
+  setTimeout(fn, 1000)
+
+  expect(fn).not.toHaveBeenCalled()
+  vi.advanceTimersByTime(1000)
+  expect(fn).toHaveBeenCalled()
+})
+
+// Other methods
+vi.runAllTimers()
+vi.runOnlyPendingTimers()
+vi.advanceTimersToNextTimer()
+vi.advanceTimersToNextFrame()  // requestAnimationFrame
+vi.clearAllTimers()
+vi.getTimerCount()
+
+// Async timer methods
+await vi.advanceTimersByTimeAsync(100)
+await vi.runAllTimersAsync()
+```
+
+## Mock Dates
+
+```ts
+vi.setSystemTime(new Date('2024-01-01'))
+expect(new Date().getFullYear()).toBe(2024)
+vi.useRealTimers()  // Restore
+
+vi.getMockedSystemTime()  // Get mocked date
+vi.getRealSystemTime()    // Get real time (ms)
+```
+
+## Mock Globals & Environment
+
+```ts
+vi.stubGlobal('fetch', vi.fn(() =>
+  Promise.resolve({ json: () => ({ data: 'mock' }) })
+))
+vi.unstubAllGlobals()
+
+vi.stubEnv('API_KEY', 'test-key')
+expect(import.meta.env.API_KEY).toBe('test-key')
+vi.unstubAllEnvs()
+```
+
+## Mock Object
+
+```ts
+const original = { method: () => 'real', nested: { fn: () => 'nested' } }
+
+const mocked = vi.mockObject(original)
+mocked.method.mockReturnValue('mocked')
+
+const spied = vi.mockObject(original, { spy: true })
+spied.method()  // 'real'
+expect(spied.method).toHaveBeenCalled()
+```
+
+## Clearing Mocks
+
+```ts
+fn.mockClear()       // Clear call history
+fn.mockReset()       // Clear history + implementation
+fn.mockRestore()     // Restore original (for spies)
+
+vi.clearAllMocks()
+vi.resetAllMocks()
+vi.restoreAllMocks()
+```
+
+## Config Auto-Reset
+
+```ts
+defineConfig({
+  test: {
+    clearMocks: true,
+    mockReset: true,
+    restoreMocks: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
+  },
+})
+```
+
+## Waiting Utilities
+
+```ts
+await vi.waitFor(async () => {
+  const el = document.querySelector('.loaded')
+  expect(el).toBeTruthy()
+}, { timeout: 5000, interval: 100 })
+
+const element = await vi.waitUntil(
+  () => document.querySelector('.loaded'),
+  { timeout: 5000 }
+)
+```
+
+## TypeScript Helper
+
+```ts
+import { myFn } from './module'
+vi.mock('./module')
+
+vi.mocked(myFn).mockReturnValue('typed')
+vi.mocked(myModule, { deep: true })
+vi.mocked(fn, { partial: true }).mockResolvedValue({ ok: true })
+```

--- a/skills/vitest/references/test-api.md
+++ b/skills/vitest/references/test-api.md
@@ -1,0 +1,195 @@
+# Test API
+
+## Basic Tests
+
+```ts
+import { describe, expect, it, test } from 'vitest'
+
+test('adds numbers', () => {
+  expect(1 + 1).toBe(2)
+})
+
+// Alias: it
+it('works the same', () => {
+  expect(true).toBe(true)
+})
+```
+
+## Async Tests
+
+```ts
+test('async test', async () => {
+  const result = await fetchData()
+  expect(result).toBeDefined()
+})
+```
+
+## Test Options
+
+```ts
+test('with options', { timeout: 10_000, retry: 2 }, async () => {})
+test('with tags', { tags: ['db', 'slow'] }, async () => {})
+```
+
+## Modifiers
+
+```ts
+test.skip('skipped', () => {})
+test.only('only this runs', () => {})
+test.todo('implement later')
+test.fails('expected to fail', () => { expect(1).toBe(2) })
+test.skipIf(process.env.CI)('not in CI', () => {})
+test.runIf(process.env.CI)('only in CI', () => {})
+
+// Dynamic skip
+test('dynamic', ({ skip }) => {
+  skip(someCondition, 'reason')
+})
+```
+
+## Concurrent & Sequential
+
+```ts
+test.concurrent('parallel 1', async ({ expect }) => {})
+test.concurrent('parallel 2', async ({ expect }) => {})
+test.sequential('must run alone', async () => {})
+```
+
+**Important:** Use `{ expect }` from context for concurrent tests.
+
+## Parameterized Tests
+
+```ts
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+])('add(%i, %i) = %i', (a, b, expected) => {
+  expect(a + b).toBe(expected)
+})
+
+test.each([
+  { a: 1, b: 1, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+])('add($a, $b) = $expected', ({ a, b, expected }) => {
+  expect(a + b).toBe(expected)
+})
+
+// test.for - preferred, doesn't spread arrays
+test.for([
+  [1, 1, 2],
+  [1, 2, 3],
+])('add(%i, %i) = %i', ([a, b, expected], { expect }) => {
+  expect(a + b).toBe(expected)
+})
+```
+
+## Describe/Suite
+
+```ts
+describe('Math', () => {
+  test('adds', () => expect(1 + 1).toBe(2))
+  test('subtracts', () => expect(3 - 1).toBe(2))
+})
+
+// Nested
+describe('User', () => {
+  describe('when logged in', () => {
+    test('shows dashboard', () => {})
+  })
+})
+
+// Modifiers
+describe.skip('skipped', () => {})
+describe.only('only this', () => {})
+describe.concurrent('parallel', () => {})
+describe.shuffle('random order', () => {})
+describe.each([{ name: 'Chrome' }, { name: 'Firefox' }])('$name', ({ name }) => {})
+```
+
+## Lifecycle Hooks
+
+```ts
+import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest'
+
+beforeAll(async () => { await setupDatabase() })
+afterAll(async () => { await teardownDatabase() })
+beforeEach(async () => { await clearTestData() })
+afterEach(async () => { await cleanupMocks() })
+
+// Return cleanup function
+beforeAll(async () => {
+  const server = await startServer()
+  return async () => { await server.close() }
+})
+```
+
+## Around Hooks
+
+```ts
+import { aroundEach, aroundAll } from 'vitest'
+
+aroundEach(async (runTest) => {
+  await db.beginTransaction()
+  await runTest()  // Must be called!
+  await db.rollback()
+})
+```
+
+## Test Hooks
+
+```ts
+import { onTestFailed, onTestFinished } from 'vitest'
+
+test('with cleanup', () => {
+  const db = connect()
+  onTestFinished(() => db.close())
+  onTestFailed(({ task }) => { console.log('Failed:', task.result?.errors) })
+})
+
+// Reusable pattern
+function useTestDb() {
+  const db = connect()
+  onTestFinished(() => db.close())
+  return db
+}
+```
+
+## Custom Fixtures
+
+```ts
+import { test as base } from 'vitest'
+
+const test = base.extend<{ db: Database; user: User }>({
+  db: async ({}, use) => {
+    const db = await createDb()
+    await use(db)
+    await db.close()
+  },
+  user: async ({ db }, use) => {
+    const user = await db.createUser({ name: 'Test' })
+    await use(user)
+    await db.deleteUser(user.id)
+  },
+})
+
+test('query', async ({ db, user }) => {
+  const found = await db.findUser(user.id)
+  expect(found).toEqual(user)
+})
+
+// Fixture options
+const test = base.extend({
+  setup: [async ({}, use) => { await use() }, { auto: true }],  // Always run
+  connection: [async ({}, use) => { /* ... */ }, { scope: 'file' }],  // Once per file
+})
+```
+
+## Hook Execution Order
+
+1. `beforeAll` (in order)
+2. `beforeEach` (in order)
+3. Test
+4. `afterEach` (reverse order)
+5. `afterAll` (reverse order)
+
+Configure with `sequence.hooks: 'stack' | 'list' | 'parallel'`

--- a/skills/vitest/references/utilities.md
+++ b/skills/vitest/references/utilities.md
@@ -1,0 +1,247 @@
+# Utilities
+
+## Expect API
+
+```ts
+import { expect } from 'vitest'
+
+// Equality
+expect(1 + 1).toBe(2)              // Strict ===
+expect({ a: 1 }).toEqual({ a: 1 }) // Deep equality
+expect({ a: 1 }).toStrictEqual({ a: 1 }) // Checks undefined props
+
+// Truthiness
+expect(true).toBeTruthy()
+expect(false).toBeFalsy()
+expect(null).toBeNull()
+expect(undefined).toBeUndefined()
+expect('value').toBeDefined()
+
+// Numbers
+expect(10).toBeGreaterThan(5)
+expect(10).toBeGreaterThanOrEqual(10)
+expect(5).toBeLessThan(10)
+expect(0.1 + 0.2).toBeCloseTo(0.3, 5)
+
+// Strings
+expect('hello world').toMatch(/world/)
+expect('hello').toContain('ell')
+
+// Arrays
+expect([1, 2, 3]).toContain(2)
+expect([{ a: 1 }]).toContainEqual({ a: 1 })
+expect([1, 2, 3]).toHaveLength(3)
+
+// Objects
+expect({ a: 1, b: 2 }).toHaveProperty('a')
+expect({ a: 1, b: 2 }).toHaveProperty('a', 1)
+expect({ a: { b: 1 } }).toHaveProperty('a.b', 1)
+expect({ a: 1 }).toMatchObject({ a: 1 })
+
+// Types
+expect('string').toBeTypeOf('string')
+expect(new Date()).toBeInstanceOf(Date)
+
+// Negation
+expect(1).not.toBe(2)
+```
+
+## Error Assertions
+
+```ts
+// Sync - wrap in function
+expect(() => throwError()).toThrow()
+expect(() => throwError()).toThrow('message')
+expect(() => throwError()).toThrow(/pattern/)
+expect(() => throwError()).toThrow(CustomError)
+
+// Async - use rejects
+await expect(asyncThrow()).rejects.toThrow('error')
+```
+
+## Promise Assertions
+
+```ts
+await expect(Promise.resolve(1)).resolves.toBe(1)
+await expect(Promise.reject('error')).rejects.toBe('error')
+```
+
+## Spy/Mock Assertions
+
+```ts
+const fn = vi.fn()
+fn('arg1', 'arg2')
+fn('arg3')
+
+expect(fn).toHaveBeenCalled()
+expect(fn).toHaveBeenCalledTimes(2)
+expect(fn).toHaveBeenCalledWith('arg1', 'arg2')
+expect(fn).toHaveBeenLastCalledWith('arg3')
+expect(fn).toHaveBeenNthCalledWith(1, 'arg1', 'arg2')
+expect(fn).toHaveReturned()
+expect(fn).toHaveReturnedWith(value)
+```
+
+## Asymmetric Matchers
+
+```ts
+expect({ id: 1, name: 'test' }).toEqual({
+  id: expect.any(Number),
+  name: expect.any(String),
+})
+
+expect({ a: 1, b: 2, c: 3 }).toEqual(expect.objectContaining({ a: 1 }))
+expect([1, 2, 3, 4]).toEqual(expect.arrayContaining([1, 3]))
+expect('hello world').toEqual(expect.stringContaining('world'))
+expect('hello world').toEqual(expect.stringMatching(/world$/))
+expect({ value: null }).toEqual({ value: expect.anything() })
+expect([1, 2]).toEqual(expect.not.arrayContaining([3]))
+```
+
+## Soft & Poll Assertions
+
+```ts
+// Continue after failure
+expect.soft(1).toBe(2)  // Marks failed but continues
+expect.soft(2).toBe(3)  // Also runs
+
+// Retry until passes
+await expect.poll(() => fetchStatus()).toBe('ready')
+await expect.poll(
+  () => document.querySelector('.element'),
+  { interval: 100, timeout: 5000 }
+).toBeTruthy()
+```
+
+## Assertion Count
+
+```ts
+test('async assertions', async () => {
+  expect.assertions(2)      // Exactly 2 must run
+  expect.hasAssertions()    // At least 1 must run
+})
+```
+
+## Custom Matchers
+
+```ts
+expect.extend({
+  toBeWithinRange(received, floor, ceiling) {
+    const pass = received >= floor && received <= ceiling
+    return {
+      pass,
+      message: () => `expected ${received} to be within ${floor} - ${ceiling}`,
+    }
+  },
+})
+
+test('custom', () => { expect(100).toBeWithinRange(90, 110) })
+```
+
+## Snapshots
+
+```ts
+expect(data).toMatchSnapshot()
+expect(data).toMatchInlineSnapshot(`{ "id": 1 }`)
+await expect(result).toMatchFileSnapshot('./expected.json')
+expect(() => { throw new Error('fail') }).toThrowErrorMatchingSnapshot()
+
+// With hints
+expect(header).toMatchSnapshot('header')
+
+// Shape matching
+expect(data).toMatchSnapshot({
+  id: expect.any(Number),
+  created: expect.any(Date),
+})
+```
+
+Update snapshots: `vitest -u` or press `u` in watch mode.
+
+### Custom Serializers
+
+```ts
+expect.addSnapshotSerializer({
+  test(val) { return val && typeof val.toJSON === 'function' },
+  serialize(val, config, indentation, depth, refs, printer) {
+    return printer(val.toJSON(), config, indentation, depth, refs)
+  },
+})
+```
+
+## Coverage
+
+```bash
+vitest run --coverage
+```
+
+```ts
+defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',  // or 'istanbul'
+      enabled: true,
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['node_modules/', 'tests/', '**/*.d.ts'],
+      all: true,  // Report uncovered files
+      thresholds: { lines: 80, functions: 80, branches: 80, statements: 80 },
+    },
+  },
+})
+```
+
+Ignore code:
+
+```ts
+/* v8 ignore next -- @preserve */
+function ignored() {}
+
+/* istanbul ignore next -- @preserve */
+function ignored() {}
+```
+
+## Filtering
+
+```bash
+vitest user                      # Files containing "user"
+vitest src/user.test.ts:25       # Specific line
+vitest -t "login"                # Tests matching pattern
+vitest --changed                 # Uncommitted changes
+vitest --changed HEAD~1          # Since commit
+vitest related src/utils.ts --run  # Tests importing file
+vitest --tags db                 # By tag
+```
+
+```ts
+test('db test', { tags: ['db', 'slow'] }, async () => {})
+```
+
+## Concurrency
+
+```ts
+defineConfig({
+  test: {
+    fileParallelism: true,
+    maxWorkers: 4,
+    pool: 'threads',  // 'threads', 'forks', 'vmThreads'
+    maxConcurrency: 5,  // Max concurrent tests per file
+    isolate: true,
+    sequence: {
+      shuffle: true,
+      seed: 12345,
+      hooks: 'stack',
+      concurrent: true,
+    },
+  },
+})
+```
+
+```ts
+describe.concurrent('parallel', () => {
+  test('test 1', async ({ expect }) => {})
+  test('test 2', async ({ expect }) => {})
+})
+
+describe.shuffle('random order', () => {})
+```

--- a/skills/vue/SKILL.md
+++ b/skills/vue/SKILL.md
@@ -35,14 +35,17 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 
 ## Quick Reference
 
-| Working on...            | Load file                  |
-| ------------------------ | -------------------------- |
-| `.vue` in `components/`  | references/components.md   |
-| File in `composables/`   | references/composables.md  |
-| File in `utils/`         | references/utils-client.md |
-| `.spec.ts` or `.test.ts` | references/testing.md      |
-| TypeScript patterns      | references/typescript.md   |
-| Vue Router typing        | references/router.md       |
+| Working on...            | Load file                    |
+| ------------------------ | ---------------------------- |
+| `.vue` in `components/`  | references/components.md     |
+| File in `composables/`   | references/composables.md    |
+| File in `utils/`         | references/utils-client.md   |
+| `.spec.ts` or `.test.ts` | references/testing.md        |
+| TypeScript patterns      | references/typescript.md     |
+| Vue Router typing        | references/router.md         |
+| Reactivity (ref, watch)  | references/reactivity.md     |
+| Custom directives        | references/directives.md     |
+| Provide/inject           | references/provide-inject.md |
 
 ## Loading Files
 
@@ -54,6 +57,9 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 - Testing → [references/testing.md](references/testing.md)
 - TypeScript → [references/typescript.md](references/typescript.md)
 - Vue Router → [references/router.md](references/router.md)
+- Reactivity → [references/reactivity.md](references/reactivity.md)
+- Custom directives → [references/directives.md](references/directives.md)
+- Provide/Inject → [references/provide-inject.md](references/provide-inject.md)
 
 **DO NOT load all files at once** - wastes context on irrelevant patterns.
 
@@ -70,6 +76,12 @@ Progressive reference system for Vue 3 projects. Load only files relevant to cur
 **[references/typescript.md](references/typescript.md)** - InjectionKey for provide/inject, vue-tsc strict templates, tsconfig settings, generic components
 
 **[references/router.md](references/router.md)** - Route meta types, typed params with unplugin-vue-router, scroll behavior, navigation guards
+
+**[references/reactivity.md](references/reactivity.md)** - ref, reactive, computed, watch, watchEffect, reactivity fundamentals
+
+**[references/directives.md](references/directives.md)** - Custom directive hooks, v-focus, v-click-outside, v-tooltip patterns
+
+**[references/provide-inject.md](references/provide-inject.md)** - InjectionKey typing, app-level provide, readonly patterns
 
 ## Examples
 

--- a/skills/vue/references/directives.md
+++ b/skills/vue/references/directives.md
@@ -1,0 +1,225 @@
+---
+name: Custom Directives
+description: Create reusable directives for low-level DOM manipulation
+---
+
+# Custom Directives
+
+Custom directives provide low-level DOM access for reusable behavior.
+
+## When to Use
+
+Use custom directives when:
+
+- You need direct DOM manipulation
+- The behavior can't be achieved with components or composables
+- You need to apply behavior to native elements
+
+## Basic Example
+
+```vue
+<script setup lang="ts">
+// v-focus directive
+const vFocus = {
+  mounted: (el: HTMLElement) => el.focus()
+}
+</script>
+
+<template>
+  <input v-focus />
+</template>
+```
+
+## Directive Hooks
+
+```ts
+const myDirective = {
+  // Before element attributes/listeners are applied
+  created(el, binding, vnode) {},
+
+  // Before element is inserted into DOM
+  beforeMount(el, binding, vnode) {},
+
+  // After element and children are mounted
+  mounted(el, binding, vnode) {},
+
+  // Before parent component updates
+  beforeUpdate(el, binding, vnode, prevVnode) {},
+
+  // After parent component updates
+  updated(el, binding, vnode, prevVnode) {},
+
+  // Before parent component unmounts
+  beforeUnmount(el, binding, vnode) {},
+
+  // After parent component unmounts
+  unmounted(el, binding, vnode) {}
+}
+```
+
+## Hook Arguments
+
+```ts
+interface DirectiveBinding<T = any> {
+  value: T           // v-my-dir="value"
+  oldValue: T        // Previous value (beforeUpdate/updated only)
+  arg?: string       // v-my-dir:arg
+  modifiers: Record<string, boolean>  // v-my-dir.foo.bar → { foo: true, bar: true }
+  instance: ComponentPublicInstance   // Component using the directive
+  dir: ObjectDirective               // Directive definition object
+}
+```
+
+Example usage:
+
+```vue-html
+<div v-example:foo.bar="baz">
+```
+
+```ts
+// binding object:
+{
+  arg: 'foo',
+  modifiers: { bar: true },
+  value: /* value of baz */,
+  oldValue: /* previous value */
+}
+```
+
+## Function Shorthand
+
+When you only need `mounted` and `updated` with same behavior:
+
+```ts
+// Full form
+const vColor = {
+  mounted(el, binding) {
+    el.style.color = binding.value
+  },
+  updated(el, binding) {
+    el.style.color = binding.value
+  }
+}
+
+// Shorthand (same behavior)
+const vColor = (el: HTMLElement, binding: DirectiveBinding<string>) => {
+  el.style.color = binding.value
+}
+```
+
+## Global Registration
+
+```ts
+// main.ts
+const app = createApp(App)
+
+app.directive('focus', {
+  mounted: (el) => el.focus()
+})
+
+// Shorthand
+app.directive('color', (el, binding) => {
+  el.style.color = binding.value
+})
+```
+
+## Object Literals
+
+Pass multiple values:
+
+```vue-html
+<div v-demo="{ color: 'white', text: 'hello' }">
+```
+
+```ts
+const vDemo = (el: HTMLElement, binding: DirectiveBinding<{ color: string; text: string }>) => {
+  console.log(binding.value.color) // 'white'
+  console.log(binding.value.text)  // 'hello'
+}
+```
+
+## Dynamic Arguments
+
+```vue-html
+<div v-my-directive:[dynamicArg]="value">
+```
+
+## Practical Examples
+
+### v-click-outside
+
+```ts
+const vClickOutside = {
+  mounted(el: HTMLElement, binding: DirectiveBinding<() => void>) {
+    el._clickOutside = (event: MouseEvent) => {
+      if (!el.contains(event.target as Node)) {
+        binding.value()
+      }
+    }
+    document.addEventListener('click', el._clickOutside)
+  },
+  unmounted(el: HTMLElement) {
+    document.removeEventListener('click', el._clickOutside)
+  }
+}
+```
+
+### v-tooltip
+
+```ts
+const vTooltip = {
+  mounted(el: HTMLElement, binding: DirectiveBinding<string>) {
+    el.setAttribute('title', binding.value)
+  },
+  updated(el: HTMLElement, binding: DirectiveBinding<string>) {
+    el.setAttribute('title', binding.value)
+  }
+}
+```
+
+### v-permission
+
+```ts
+const vPermission = {
+  mounted(el: HTMLElement, binding: DirectiveBinding<string>) {
+    if (!hasPermission(binding.value)) {
+      el.parentNode?.removeChild(el)
+    }
+  }
+}
+```
+
+## TypeScript: Global Directives
+
+```ts
+// directives/highlight.ts
+import type { Directive } from 'vue'
+
+export type HighlightDirective = Directive<HTMLElement, string>
+
+declare module 'vue' {
+  export interface ComponentCustomProperties {
+    vHighlight: HighlightDirective
+  }
+}
+
+export default {
+  mounted: (el, binding) => {
+    el.style.backgroundColor = binding.value
+  }
+} satisfies HighlightDirective
+```
+
+## Usage on Components
+
+⚠️ **Not recommended** - directives apply to root element, which can be unpredictable with multi-root components.
+
+```vue-html
+<!-- Applies to MyComponent's root element -->
+<MyComponent v-my-directive />
+```
+
+<!--
+Source references:
+- https://vuejs.org/guide/reusability/custom-directives.html
+-->

--- a/skills/vue/references/provide-inject.md
+++ b/skills/vue/references/provide-inject.md
@@ -1,0 +1,174 @@
+---
+name: Provide / Inject
+description: Pass data through component tree without prop drilling
+---
+
+# Provide / Inject
+
+Provide data from ancestor components to any descendant, avoiding prop drilling.
+
+## Basic Usage
+
+```vue
+<!-- Provider.vue -->
+<script setup lang="ts">
+import { provide, ref } from 'vue'
+
+const message = ref('hello')
+provide('message', message)
+</script>
+```
+
+```vue
+<!-- DeepChild.vue (any level deep) -->
+<script setup lang="ts">
+import { inject } from 'vue'
+
+const message = inject('message')
+</script>
+```
+
+## Typing with InjectionKey
+
+Use `InjectionKey` for type safety between provider and injector:
+
+```ts
+// keys.ts
+import type { InjectionKey, Ref } from 'vue'
+
+export const messageKey = Symbol() as InjectionKey<Ref<string>>
+export const countKey = Symbol() as InjectionKey<number>
+```
+
+```vue
+<!-- Provider.vue -->
+<script setup lang="ts">
+import { provide, ref } from 'vue'
+import { messageKey } from './keys'
+
+const message = ref('hello')
+provide(messageKey, message)
+</script>
+```
+
+```vue
+<!-- Injector.vue -->
+<script setup lang="ts">
+import { inject } from 'vue'
+import { messageKey } from './keys'
+
+const message = inject(messageKey) // Ref<string> | undefined
+</script>
+```
+
+## Default Values
+
+```ts
+// Simple default
+const value = inject('message', 'default value')
+
+// Factory function (for expensive defaults)
+const value = inject('key', () => new ExpensiveClass(), true)
+//                                                       ^ treat as factory
+```
+
+## App-Level Provide
+
+Available to all components:
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+
+const app = createApp(App)
+app.provide('globalConfig', { theme: 'dark' })
+```
+
+## Reactive Provide/Inject
+
+Provide reactive values for automatic updates:
+
+```vue
+<!-- Provider.vue -->
+<script setup lang="ts">
+import { provide, ref } from 'vue'
+
+const count = ref(0)
+provide('count', count)
+</script>
+```
+
+The injected value maintains reactivity connection.
+
+## Mutations Best Practice
+
+Keep mutations in the provider, expose update functions:
+
+```vue
+<!-- Provider.vue -->
+<script setup lang="ts">
+import { provide, ref, readonly } from 'vue'
+
+const location = ref('North Pole')
+
+function updateLocation(newLocation: string) {
+  location.value = newLocation
+}
+
+provide('location', {
+  location: readonly(location), // Prevent direct mutation
+  updateLocation
+})
+</script>
+```
+
+```vue
+<!-- Injector.vue -->
+<script setup lang="ts">
+import { inject } from 'vue'
+
+const { location, updateLocation } = inject('location')!
+</script>
+
+<template>
+  <button @click="updateLocation('South Pole')">
+    {{ location }}
+  </button>
+</template>
+```
+
+## Using Symbol Keys
+
+Recommended for libraries and large apps to avoid collisions:
+
+```ts
+// keys.ts
+export const myKey = Symbol('myKey')
+
+// provider
+provide(myKey, value)
+
+// injector
+inject(myKey)
+```
+
+## Type Helpers
+
+```ts
+// String key with explicit type
+const foo = inject<string>('foo')
+//    ^? string | undefined
+
+// With default (removes undefined)
+const foo = inject<string>('foo', 'default')
+//    ^? string
+
+// Force non-undefined (use when certain it's provided)
+const foo = inject('foo') as string
+```
+
+<!--
+Source references:
+- https://vuejs.org/guide/components/provide-inject.html
+- https://vuejs.org/guide/typescript/composition-api.html#typing-provide-inject
+-->

--- a/skills/vue/references/reactivity.md
+++ b/skills/vue/references/reactivity.md
@@ -1,0 +1,289 @@
+---
+name: Vue Reactivity System
+description: Core reactivity primitives - ref, reactive, computed, and watchers
+---
+
+# Vue Reactivity System
+
+Vue's reactivity system enables automatic tracking of state changes and DOM updates.
+
+## ref()
+
+Create reactive primitive values with `ref()`. Access/modify via `.value` in JavaScript, auto-unwrapped in templates.
+
+```ts
+import { ref } from 'vue'
+
+const count = ref(0)
+console.log(count.value) // 0
+count.value++
+```
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+
+function increment() {
+  count.value++
+}
+</script>
+
+<template>
+  <button @click="increment">{{ count }}</button>
+</template>
+```
+
+### Typing refs
+
+```ts
+import { ref } from 'vue'
+import type { Ref } from 'vue'
+
+// Type inference
+const year = ref(2020) // Ref<number>
+
+// Explicit generic
+const name = ref<string | null>(null)
+
+// Ref type annotation
+const id: Ref<string | number> = ref('abc')
+```
+
+## reactive()
+
+Create reactive objects. No `.value` needed, but cannot reassign the entire object.
+
+```ts
+import { reactive } from 'vue'
+
+interface State {
+  count: number
+  name: string
+}
+
+const state: State = reactive({
+  count: 0,
+  name: 'Vue'
+})
+
+state.count++ // reactive
+```
+
+### Limitations of reactive()
+
+1. **Only works with objects** - not primitives
+2. **Cannot replace entire object** - loses reactivity
+3. **Destructuring loses reactivity** - use `toRefs()` instead
+
+```ts
+const state = reactive({ count: 0 })
+
+// ❌ Loses reactivity
+let { count } = state
+
+// ✅ Use toRefs
+import { toRefs } from 'vue'
+const { count } = toRefs(state)
+```
+
+## Recommendation
+
+Use `ref()` as the primary API for declaring reactive state - it works with any value type and has consistent behavior.
+
+## Deep Reactivity
+
+Both `ref()` and `reactive()` are deeply reactive by default:
+
+```ts
+const obj = ref({
+  nested: { count: 0 },
+  arr: ['foo', 'bar']
+})
+
+// These trigger updates
+obj.value.nested.count++
+obj.value.arr.push('baz')
+```
+
+Use `shallowRef()` or `shallowReactive()` to opt out of deep reactivity for performance.
+
+## DOM Update Timing
+
+DOM updates are batched and asynchronous. Use `nextTick()` to wait for updates:
+
+```ts
+import { ref, nextTick } from 'vue'
+
+const count = ref(0)
+
+async function increment() {
+  count.value++
+  await nextTick()
+  // DOM is now updated
+}
+```
+
+## Ref Unwrapping Rules
+
+- **In templates**: Top-level refs auto-unwrap
+- **In reactive objects**: Refs auto-unwrap when accessed as properties
+- **In arrays/collections**: Refs do NOT auto-unwrap
+
+```ts
+const count = ref(0)
+const state = reactive({ count })
+
+console.log(state.count) // 0 (unwrapped)
+
+const books = reactive([ref('Vue Guide')])
+console.log(books[0].value) // Need .value
+```
+
+## computed()
+
+Derive values from reactive state with automatic caching. Only re-evaluates when dependencies change.
+
+```ts
+import { ref, computed } from 'vue'
+
+const firstName = ref('John')
+const lastName = ref('Doe')
+
+// Readonly computed
+const fullName = computed(() => `${firstName.value} ${lastName.value}`)
+
+// Writable computed
+const fullNameWritable = computed({
+  get() {
+    return `${firstName.value} ${lastName.value}`
+  },
+  set(newValue: string) {
+    [firstName.value, lastName.value] = newValue.split(' ')
+  }
+})
+```
+
+### Computed Best Practices
+
+- **Getters should be pure** - no side effects, no mutating other state
+- **Don't mutate computed values** - mutate the source instead
+- **Use computed over methods** for derived data (caching benefit)
+
+```ts
+// ✅ Cached - only recalculates when items changes
+const activeItems = computed(() => items.value.filter(x => x.active))
+
+// ❌ Not cached - runs on every render
+function getActiveItems() {
+  return items.value.filter(x => x.active)
+}
+```
+
+## watch()
+
+Explicitly watch reactive sources and run side effects when they change. Lazy by default.
+
+```ts
+import { ref, watch } from 'vue'
+
+const id = ref(1)
+
+watch(id, async (newId, oldId) => {
+  const data = await fetchData(newId)
+  // handle data...
+})
+```
+
+### Watch Source Types
+
+```ts
+const x = ref(0)
+const obj = reactive({ count: 0 })
+
+// Single ref
+watch(x, (newX) => console.log(newX))
+
+// Getter function
+watch(() => obj.count, (count) => console.log(count))
+
+// Multiple sources
+watch([x, () => obj.count], ([newX, newCount]) => {
+  console.log(newX, newCount)
+})
+```
+
+### Watch Options
+
+```ts
+watch(source, callback, {
+  immediate: true,  // Run immediately on creation
+  deep: true,       // Watch nested properties
+  once: true,       // Trigger only once (3.4+)
+  flush: 'post'     // Run after DOM update
+})
+```
+
+## watchEffect()
+
+Automatically tracks dependencies and runs immediately. Re-runs when any tracked dependency changes.
+
+```ts
+import { ref, watchEffect } from 'vue'
+
+const todoId = ref(1)
+const data = ref(null)
+
+watchEffect(async () => {
+  const response = await fetch(`/api/todos/${todoId.value}`)
+  data.value = await response.json()
+})
+```
+
+### watch vs watchEffect
+
+| Feature             | watch            | watchEffect           |
+| ------------------- | ---------------- | --------------------- |
+| Dependency tracking | Explicit         | Automatic             |
+| Lazy                | Yes              | No (immediate)        |
+| Access old value    | Yes              | No                    |
+| Best for            | Specific sources | Multiple dependencies |
+
+## Watcher Cleanup (3.5+)
+
+Cancel stale async operations:
+
+```ts
+import { watch, onWatcherCleanup } from 'vue'
+
+watch(id, async (newId) => {
+  const controller = new AbortController()
+
+  fetch(`/api/${newId}`, { signal: controller.signal })
+
+  onWatcherCleanup(() => controller.abort())
+})
+```
+
+## Stopping Watchers
+
+```ts
+const stop = watch(source, callback)
+const stop2 = watchEffect(() => { /* ... */ })
+
+// Stop manually
+stop()
+stop2()
+
+// Pause/Resume (3.5+)
+const { stop, pause, resume } = watchEffect(() => { /* ... */ })
+```
+
+<!--
+Source references:
+- https://vuejs.org/guide/essentials/reactivity-fundamentals.html
+- https://vuejs.org/guide/essentials/computed.html
+- https://vuejs.org/guide/essentials/watchers.html
+- https://vuejs.org/api/reactivity-core.html
+-->


### PR DESCRIPTION
## Summary

Adds 4 skills from [antfu/skills](https://github.com/antfu/skills) (MIT), consolidated to our style.

### New Skills
| Skill | Refs | Topics |
|-------|------|--------|
| vitest | 5 | config, test-api, mocking, utilities, advanced |
| vite | 5 | config, features, dev, build, advanced |
| pnpm | 4 | cli, workspaces, features, ci |
| tsdown | 4 | config, output, features, advanced |

### Also
- **vue** - Added reactivity, directives, provide-inject refs
- **ts-library** - Added eslint-config ref
- **CI** - New `sync-antfu-skills` job to track upstream