### PR TITLE
feat: add Nuxt I18n skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "source": "./",
       "version": "1.1.0",
       "description": "Vue, Nuxt, and NuxtHub skills for AI coding assistants",
-      "keywords": ["vue", "nuxt", "nuxthub", "nuxt-modules", "nuxt-content", "nuxt-studio", "nuxt-ui", "nuxt-seo", "vite", "vitest", "pnpm", "tsdown"],
+      "keywords": ["vue", "nuxt", "nuxthub", "nuxt-modules", "nuxt-content", "nuxt-studio", "nuxt-ui", "nuxt-i18n", "nuxt-seo", "vite", "vitest", "pnpm", "tsdown"],
       "category": "frontend"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Clone the repository and copy skill folders to your agent's skills directory:
 | **nuxt-content**              | Nuxt Content collections, schemas, queries, navigation, search, MDC, and deployment     |
 | **nuxt-studio**               | Nuxt Studio setup, auth, visual editing, drafts, media, AI, and Git publishing          |
 | **nuxt-ui**                   | Nuxt UI v4 components, theming, forms, overlays, composables                            |
+| **nuxt-i18n**                 | Nuxt I18n locales, messages, routing, language switching, fallbacks, and locale SEO     |
 | **nuxt-better-auth**          | Auth with @onmax/nuxt-better-auth, useUserSession, route protection, clientOnly         |
 | **reka-ui**                   | Reka UI headless Vue components, accessible primitives, props/emits/slots               |
 | **document-writer**           | Writing documentation for Nuxt ecosystem - MDC, style, structure, code examples         |
@@ -117,6 +118,7 @@ nuxt-skills/
 │   ├── nuxt-content/
 │   ├── nuxt-studio/
 │   ├── nuxt-ui/
+│   ├── nuxt-i18n/
 │   ├── nuxt-better-auth/
 │   ├── reka-ui/
 │   ├── document-writer/

--- a/skills/nuxt-i18n/SKILL.md
+++ b/skills/nuxt-i18n/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: nuxt-i18n
+description: Internationalize Nuxt applications with @nuxtjs/i18n. Use when configuring locales or browser detection, translating messages or routes, building locale switchers, handling fallbacks, lazy-loading messages, or adding locale SEO.
+license: MIT
+---
+
+# Nuxt I18n
+
+Nuxt I18n owns locale messages, localized routes, language detection, and locale metadata. Nuxt owns the surrounding page, rendering, and server lifecycle.
+
+## Workflow
+
+1. Inspect the installed `@nuxtjs/i18n` version, `nuxt.config.*`, `i18n/i18n.config.*`, locale files, and affected pages. The setup is understood when locale codes, files, `defaultLocale`, and the routing strategy agree.
+2. Open the smallest matching guide below. Keep module options in `nuxt.config`, Vue I18n options in `i18n.config`, and translated messages in locale files.
+3. Implement with localized links and module composables so routing, message loading, and SEO share one locale state.
+4. Run `nuxi prepare` and the project's typecheck, then visit the affected route in the default and one secondary locale. The change is complete when both locales render the expected message, URL, language metadata, and fallback behavior.
+
+## Routing
+
+| Task                                                                                 | Open                                         |
+| ------------------------------------------------------------------------------------ | -------------------------------------------- |
+| Installation, locale objects, file layout, browser detection, or Vue I18n config     | [Configuration](references/configuration.md) |
+| Translation keys, interpolation, plurals, dates, numbers, or runtime message loading | [Messages](references/messages.md)           |
+| Route strategies, localized links, switchers, custom paths, dynamic slugs, or SEO    | [Routing and SEO](references/routing.md)     |
+| Nuxt pages, middleware, data fetching, SSR state, or server routes                   | `nuxt` skill                                 |
+
+## Baseline
+
+```bash
+npx nuxi@latest module add @nuxtjs/i18n
+```
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', language: 'en-US', name: 'English', file: 'en.json' },
+      { code: 'fr', language: 'fr-FR', name: 'Français', file: 'fr.json' },
+    ],
+  },
+})
+```
+
+```json
+{
+  "welcome": "Welcome"
+}
+```
+
+Locale files resolve from `i18n/locales/` by default. Use the same locale code in configuration, route helpers, locale files, and fallback rules.

--- a/skills/nuxt-i18n/references/configuration.md
+++ b/skills/nuxt-i18n/references/configuration.md
@@ -1,0 +1,122 @@
+# Configuration
+
+## Inspect the existing setup
+
+Read the installed `@nuxtjs/i18n` version before choosing an API. Then inspect:
+
+- `nuxt.config.*` for module options, locales, routing, and detection
+- `i18n/i18n.config.*` for Vue I18n options such as fallback and formats
+- `i18n/locales/` or the configured `langDir` for message resources
+- route and locale middleware that may already change the active locale
+
+Keep locale codes as the shared identifiers across all four surfaces.
+
+## Define locale identity
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    locales: [
+      {
+        code: 'en',
+        language: 'en-US',
+        name: 'English',
+        file: 'en.json',
+        dir: 'ltr',
+      },
+      {
+        code: 'ar',
+        language: 'ar-EG',
+        name: 'العربية',
+        file: 'ar.json',
+        dir: 'rtl',
+      },
+    ],
+  },
+})
+```
+
+Use:
+
+- `code` as the runtime and routing identifier
+- `language` as the BCP 47 tag for browser matching and SEO
+- `name` as the human-readable switcher label
+- `file` or `files` for locale resources
+- `dir` when the locale's writing direction differs from the default
+
+Locale files resolve from `i18n/locales/` by default. `langDir` is relative to the `i18n/` restructure directory, so keep it relative.
+
+## Module options and Vue I18n options
+
+Routing, locale files, browser detection, domains, and SEO base URLs belong in `nuxt.config`:
+
+```ts
+export default defineNuxtConfig({
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', language: 'en-US', file: 'en.json' },
+      { code: 'fr', language: 'fr-FR', file: 'fr.json' },
+    ],
+  },
+})
+```
+
+Fallbacks and number or date formats belong in `i18n/i18n.config.ts`:
+
+```ts
+export default defineI18nConfig(() => ({
+  fallbackLocale: 'en',
+}))
+```
+
+`defaultLocale` selects the default route locale. `fallbackLocale` selects messages when the active locale lacks a key; configure both deliberately.
+
+## Browser language detection
+
+Use root-only detection for public, indexable sites so explicit locale URLs remain stable:
+
+```ts
+export default defineNuxtConfig({
+  i18n: {
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: 'i18n_redirected',
+      fallbackLocale: 'en',
+      redirectOn: 'root',
+    },
+  },
+})
+```
+
+Set `detectBrowserLanguage: false` when the application, account, domain, or upstream middleware owns locale selection. Preserve a user's explicit choice through `setLocale()` or localized navigation, and reserve detection for the entry points that need it.
+
+## Locale files and loading
+
+Static locale files are lazy-loaded when they are listed with `file` or `files`:
+
+```ts
+export default defineNuxtConfig({
+  i18n: {
+    locales: [
+      { code: 'en', files: ['en/common.json', 'en/app.json'] },
+      { code: 'fr', files: ['fr/common.json', 'fr/app.json'] },
+    ],
+  },
+})
+```
+
+Files load in array order, and later files override earlier keys. Put shared messages first and narrower overrides last.
+
+## Verification
+
+Run `npx nuxi prepare` after changing module configuration, then run the project's typecheck. Start Nuxt and verify:
+
+- every configured locale file loads without warnings
+- the default locale matches the unprefixed route when using `prefix_except_default`
+- a missing secondary-locale key resolves through the intended fallback
+- browser detection redirects only on the configured paths
+- `lang` and `dir` reflect the active locale

--- a/skills/nuxt-i18n/references/messages.md
+++ b/skills/nuxt-i18n/references/messages.md
@@ -1,0 +1,116 @@
+# Messages
+
+## Translate in components
+
+Use `useI18n()` in script and `$t` in templates:
+
+```json
+{
+  "greeting": "Hello, {name}!",
+  "cart": {
+    "items": "no items | one item | {count} items"
+  }
+}
+```
+
+```vue
+<script setup lang="ts">
+const { t } = useI18n()
+const name = ref('Ada')
+const itemCount = ref(2)
+
+const greeting = computed(() => t('greeting', { name: name.value }))
+</script>
+
+<template>
+  <h1>{{ greeting }}</h1>
+  <p>{{ $t('cart.items', itemCount) }}</p>
+</template>
+```
+
+Use stable semantic keys such as `checkout.submit` so copy changes leave the message API intact. Give every locale the same message tree so missing keys reveal translation gaps and structural drift.
+
+## Dates and numbers
+
+Define named formats once in `i18n/i18n.config.ts`:
+
+```ts
+export default defineI18nConfig(() => ({
+  datetimeFormats: {
+    en: {
+      short: { year: 'numeric', month: 'short', day: 'numeric' },
+    },
+    fr: {
+      short: { year: 'numeric', month: 'short', day: 'numeric' },
+    },
+  },
+  numberFormats: {
+    en: {
+      currency: { style: 'currency', currency: 'USD' },
+    },
+    fr: {
+      currency: { style: 'currency', currency: 'EUR' },
+    },
+  },
+}))
+```
+
+```vue
+<script setup lang="ts">
+const { d, n } = useI18n()
+</script>
+
+<template>
+  <p>{{ d(new Date(), 'short') }}</p>
+  <p>{{ n(1299, 'currency') }}</p>
+</template>
+```
+
+Named formats keep components independent from locale-specific punctuation, ordering, and currency placement.
+
+## Shared and component-local messages
+
+Put navigation, validation, and cross-page messages in locale files. Use a component `<i18n>` block when the messages belong only to that component:
+
+```vue
+<i18n lang="json">
+{
+  "en": { "label": "Search" },
+  "fr": { "label": "Rechercher" }
+}
+</i18n>
+
+<template>
+  <label>{{ $t('label') }}</label>
+</template>
+```
+
+This boundary keeps reusable global keys centralized while allowing genuinely local copy to travel with its component.
+
+## Runtime messages
+
+Use `defineI18nLocale()` when a locale resource comes from an API:
+
+```ts
+// i18n/locales/en.ts
+export default defineI18nLocale((locale) => {
+  return $fetch(`/api/locales/${locale}`)
+})
+```
+
+Configure that resource with `file: 'en.ts'`, and keep response shapes identical across locales so message paths remain predictable.
+
+Use `loadLocaleMessages(locale)` when the current view needs a non-active locale:
+
+```ts
+const { loadLocaleMessages, t } = useI18n()
+
+await loadLocaleMessages('fr')
+const frenchTitle = computed(() => t('title', 1, { locale: 'fr' }))
+```
+
+Cache and reuse remote results at the owning API boundary. Repeated manual loading adds latency and makes fallback behavior harder to reason about.
+
+## Verification
+
+Check one interpolation, plural, date, number, and missing-key case in both the default and secondary locale. The message branch is complete when the same key paths work in every locale and missing keys resolve through the configured fallback without console warnings.

--- a/skills/nuxt-i18n/references/routing.md
+++ b/skills/nuxt-i18n/references/routing.md
@@ -1,0 +1,141 @@
+# Routing and SEO
+
+## Choose one route strategy
+
+| Strategy                | Generated URLs                     | Use when                                     |
+| ----------------------- | ---------------------------------- | -------------------------------------------- |
+| `prefix_except_default` | `/about`, `/fr/about`              | The default locale should keep clean URLs    |
+| `prefix`                | `/en/about`, `/fr/about`           | Every locale needs an explicit URL namespace |
+| `prefix_and_default`    | `/about`, `/en/about`, `/fr/about` | The default locale needs both URL forms      |
+| `no_prefix`             | `/about` for every locale          | URLs are intentionally locale-neutral        |
+
+`prefix_except_default` is the module default and the usual public-site baseline. `no_prefix` relies on locale state rather than the URL, so use `setLocale()` for switching and plan caching and SEO around the shared route.
+
+## Localized links
+
+Use `<NuxtLinkLocale>` for application links:
+
+```vue
+<template>
+  <nav>
+    <NuxtLinkLocale to="/">Home</NuxtLinkLocale>
+    <NuxtLinkLocale to="about">About</NuxtLinkLocale>
+  </nav>
+</template>
+```
+
+Use `useLocalePath()` when code needs the localized URL:
+
+```ts
+const localePath = useLocalePath()
+
+await navigateTo(localePath({ name: 'products-id', params: { id: product.id } }))
+```
+
+Named routes preserve custom localized paths more reliably than hand-built strings.
+
+## Locale switchers
+
+Use `<SwitchLocalePathLink>` to navigate to the current page in another locale:
+
+```vue
+<script setup lang="ts">
+const { locale, locales } = useI18n()
+
+const availableLocales = computed(() => {
+  return locales.value.filter(entry => entry.code !== locale.value)
+})
+</script>
+
+<template>
+  <nav aria-label="Language">
+    <SwitchLocalePathLink
+      v-for="entry in availableLocales"
+      :key="entry.code"
+      :locale="entry.code"
+    >
+      {{ entry.name }}
+    </SwitchLocalePathLink>
+  </nav>
+</template>
+```
+
+This component resolves translated dynamic parameters during server rendering. Use `await setLocale(code)` for `no_prefix` applications or controls that intentionally change language without navigating.
+
+## Custom route paths
+
+Define translated static paths with page metadata:
+
+```vue
+<script setup lang="ts">
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/about',
+      fr: '/a-propos',
+    },
+  },
+})
+</script>
+```
+
+Set `customRoutes: 'meta'` in `nuxt.config` when page metadata is the sole source of custom paths. Keep configured paths free of locale prefixes; the route strategy adds them.
+
+For translated dynamic parameters, register each locale's value after loading the page data:
+
+```vue
+<script setup lang="ts">
+const route = useRoute()
+const { data: product } = await useFetch(`/api/products/${route.params.slug}`)
+
+const setI18nParams = useSetI18nParams()
+setI18nParams({
+  en: { slug: product.value?.slugs.en },
+  fr: { slug: product.value?.slugs.fr },
+})
+</script>
+```
+
+Render the switcher with `<SwitchLocalePathLink>` so server-rendered links receive the translated parameters before the response is sent.
+
+## Locale SEO
+
+Configure BCP 47 `language` values and a production `baseUrl`:
+
+```ts
+export default defineNuxtConfig({
+  i18n: {
+    baseUrl: 'https://example.com',
+    locales: [
+      { code: 'en', language: 'en-US', file: 'en.json' },
+      { code: 'fr', language: 'fr-FR', file: 'fr.json' },
+    ],
+  },
+})
+```
+
+Apply locale metadata once in `app.vue` or the default layout:
+
+```vue
+<script setup lang="ts">
+const i18nHead = useLocaleHead({ seo: true })
+
+useHead(() => ({
+  htmlAttrs: i18nHead.value.htmlAttrs,
+  link: i18nHead.value.link,
+  meta: i18nHead.value.meta,
+}))
+</script>
+```
+
+This keeps `html[lang]`, writing direction, canonical URLs, alternate-language links, and Open Graph locale tags aligned with the active route.
+
+## Verification
+
+For each supported locale, open one static and one dynamic route and verify:
+
+- internal links keep the active locale
+- the switcher resolves the equivalent page and translated dynamic parameter
+- custom paths match `definePageMeta`
+- the document language and direction match the locale
+- canonical and `hreflang` URLs are absolute and point to valid localized routes


### PR DESCRIPTION
## Summary

- add a model-invoked `nuxt-i18n` skill with a short, checkable workflow
- progressively disclose configuration, messages, and routing/SEO guidance
- cover locale files, browser detection, fallbacks, switchers, translated routes, dynamic parameters, and locale metadata
- expose the skill in the README and marketplace keywords

## Validation

- `pnpm exec eslint README.md .claude-plugin/marketplace.json skills/nuxt-i18n`
- `pnpm typecheck`
- `git diff --check`
- static frontmatter and local reference-link validation

The repository-wide `pnpm lint` still reports pre-existing formatting errors in generated Reka UI Markdown; all files changed by this PR pass focused lint.

Closes #66